### PR TITLE
Fix #142: Add missing documentation for webhooks, apikeys, and evals collections

### DIFF
--- a/content/admin/apikeys.mdx
+++ b/content/admin/apikeys.mdx
@@ -1,0 +1,313 @@
+# API Keys
+
+Create and manage API keys for secure access to your AI applications.
+
+## Overview
+
+API Keys provide a way to securely access your AI applications. API Keys can:
+
+- Authenticate API requests
+- Control access to resources
+- Track usage and costs
+- Manage permissions and scopes
+
+## Key Features
+
+- **Authentication**: Securely authenticate API requests
+- **Access Control**: Control access to resources
+- **Usage Tracking**: Track API usage and costs
+- **Permissions Management**: Manage permissions and scopes
+
+## Creating API Keys
+
+Create API keys using the Admin.do API:
+
+```typescript
+// Create an API key
+const apiKey = await admin.apiKeys.create({
+  name: 'My API Key',
+  description: 'An API key for my application',
+  organization: 'org-123',
+  expiresAt: '2024-12-31T23:59:59Z',
+  scopes: ['functions:read', 'functions:write', 'workflows:read', 'workflows:execute'],
+  projects: ['proj-123', 'proj-456'],
+  restrictions: {
+    ipAddresses: ['192.168.1.1/24', '10.0.0.1/16'],
+    referrers: ['example.com', '*.example.org']
+  }
+})
+
+// The API key is only returned once
+console.log(`API Key: ${apiKey.key}`)
+```
+
+## Managing API Keys
+
+Manage API keys using the Admin.do API:
+
+```typescript
+// Get all API keys
+const apiKeys = await admin.apiKeys.list({
+  organization: 'org-123',
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific API key
+const apiKey = await admin.apiKeys.get('key-123')
+
+// Update an API key
+const updatedApiKey = await admin.apiKeys.update('key-123', {
+  name: 'My Updated API Key',
+  description: 'An updated API key for my application',
+  expiresAt: '2025-12-31T23:59:59Z',
+  scopes: ['functions:read', 'functions:write', 'workflows:read', 'workflows:execute', 'agents:read'],
+  projects: ['proj-123', 'proj-456', 'proj-789'],
+  restrictions: {
+    ipAddresses: ['192.168.1.1/24', '10.0.0.1/16', '172.16.0.1/16'],
+    referrers: ['example.com', '*.example.org', '*.example.net']
+  }
+})
+
+// Delete an API key
+await admin.apiKeys.delete('key-123')
+
+// Revoke an API key
+await admin.apiKeys.revoke('key-123', {
+  reason: 'Security concern'
+})
+```
+
+## API Key Scopes
+
+API keys can have various scopes to control access to resources:
+
+### Function Scopes
+
+- `functions:read`: Read functions
+- `functions:write`: Create, update, and delete functions
+- `functions:execute`: Execute functions
+
+### Workflow Scopes
+
+- `workflows:read`: Read workflows
+- `workflows:write`: Create, update, and delete workflows
+- `workflows:execute`: Execute workflows
+
+### Agent Scopes
+
+- `agents:read`: Read agents
+- `agents:write`: Create, update, and delete agents
+- `agents:execute`: Execute agents
+
+### Data Scopes
+
+- `data:read`: Read data
+- `data:write`: Create, update, and delete data
+
+### Event Scopes
+
+- `events:read`: Read events
+- `events:write`: Create, update, and delete events
+- `events:trigger`: Trigger events
+
+### Admin Scopes
+
+- `admin:read`: Read admin resources
+- `admin:write`: Create, update, and delete admin resources
+- `admin:users`: Manage users
+- `admin:organizations`: Manage organizations
+- `admin:projects`: Manage projects
+- `admin:billing`: Manage billing
+
+## API Key Usage
+
+Track API key usage using the Admin.do API:
+
+```typescript
+// Get API key usage
+const usage = await admin.apiKeys.getUsage('key-123', {
+  timeRange: {
+    start: '2023-06-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  resources: ['functions', 'workflows', 'agents'],
+  groupBy: 'day'
+})
+
+// Get usage by resource
+const functionUsage = await admin.apiKeys.getResourceUsage('key-123', 'functions', {
+  timeRange: {
+    start: '2023-06-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  groupBy: 'day'
+})
+
+// Get usage by project
+const projectUsage = await admin.apiKeys.getProjectUsage('key-123', 'proj-123', {
+  timeRange: {
+    start: '2023-06-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  resources: ['functions', 'workflows', 'agents']
+})
+```
+
+## API Key Logs
+
+View API key logs using the Admin.do API:
+
+```typescript
+// Get API key logs
+const logs = await admin.apiKeys.getLogs('key-123', {
+  timeRange: {
+    start: '2023-06-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  status: 'success',
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific log entry
+const log = await admin.apiKeys.getLog('key-123', 'log-123')
+```
+
+## API Key Restrictions
+
+Restrict API key usage using the Admin.do API:
+
+```typescript
+// Update API key restrictions
+const updatedApiKey = await admin.apiKeys.updateRestrictions('key-123', {
+  ipAddresses: ['192.168.1.1/24', '10.0.0.1/16', '172.16.0.1/16'],
+  referrers: ['example.com', '*.example.org', '*.example.net'],
+  rateLimit: {
+    requests: 1000,
+    period: 'minute'
+  },
+  timeRestrictions: {
+    daysOfWeek: ['monday', 'tuesday', 'wednesday', 'thursday', 'friday'],
+    hoursOfDay: [9, 10, 11, 12, 13, 14, 15, 16, 17],
+    timezone: 'America/New_York'
+  }
+})
+```
+
+## API Key Rotation
+
+Rotate API keys using the Admin.do API:
+
+```typescript
+// Rotate an API key
+const newApiKey = await admin.apiKeys.rotate('key-123', {
+  expiresAt: '2025-12-31T23:59:59Z'
+})
+
+// The new API key is only returned once
+console.log(`New API Key: ${newApiKey.key}`)
+```
+
+## Using API Keys
+
+Use API keys to authenticate API requests:
+
+```typescript
+// Node.js example
+const axios = require('axios')
+
+const apiKey = 'your-api-key'
+const baseUrl = 'https://api.admin.do'
+
+// Create a function
+const createFunction = async () => {
+  try {
+    const response = await axios.post(
+      `${baseUrl}/functions`,
+      {
+        name: 'My Function',
+        description: 'A function for my application',
+        input: {
+          name: {
+            type: 'string',
+            description: 'The name to greet'
+          }
+        },
+        output: {
+          greeting: {
+            type: 'string',
+            description: 'The greeting message'
+          }
+        },
+        code: `
+          const { name } = input;
+          return {
+            greeting: \`Hello, \${name}!\`
+          };
+        `
+      },
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    
+    console.log('Function created:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('Error creating function:', error.response?.data || error.message)
+    throw error
+  }
+}
+
+// Execute a function
+const executeFunction = async (functionId, input) => {
+  try {
+    const response = await axios.post(
+      `${baseUrl}/functions/${functionId}/execute`,
+      input,
+      {
+        headers: {
+          'Authorization': `Bearer ${apiKey}`,
+          'Content-Type': 'application/json'
+        }
+      }
+    )
+    
+    console.log('Function executed:', response.data)
+    return response.data
+  } catch (error) {
+    console.error('Error executing function:', error.response?.data || error.message)
+    throw error
+  }
+}
+
+// Usage
+const main = async () => {
+  const func = await createFunction()
+  const result = await executeFunction(func.id, { name: 'John' })
+  console.log(result.output.greeting) // "Hello, John!"
+}
+
+main()
+```
+
+## API Key Best Practices
+
+- **Never share API keys**: Keep your API keys secure and never share them publicly
+- **Use environment variables**: Store API keys in environment variables, not in code
+- **Set appropriate scopes**: Only grant the permissions that are needed
+- **Rotate keys regularly**: Rotate API keys periodically to enhance security
+- **Monitor usage**: Regularly monitor API key usage for suspicious activity
+- **Set expiration dates**: Set expiration dates for API keys to limit their lifetime
+- **Use IP restrictions**: Restrict API key usage to specific IP addresses
+- **Implement rate limiting**: Set rate limits to prevent abuse
+
+## Next Steps
+
+- [Create your first API key](/admin/apikeys/create)
+- [Secure your API keys](/admin/apikeys/security)
+- [Monitor API key usage](/admin/apikeys/monitoring)

--- a/content/admin/webhooks.mdx
+++ b/content/admin/webhooks.mdx
@@ -1,0 +1,344 @@
+# Webhooks
+
+Configure and manage webhooks to receive real-time notifications about events in your AI applications.
+
+## Overview
+
+Webhooks provide a way to receive real-time notifications about events in your AI applications. Webhooks can:
+
+- Notify external systems about events
+- Trigger external workflows
+- Enable real-time integrations
+- Provide event-driven architecture
+
+## Key Features
+
+- **Event Notifications**: Receive notifications about events in your AI applications
+- **Customizable Payloads**: Configure the payload format for webhook notifications
+- **Retry Mechanisms**: Automatically retry failed webhook deliveries
+- **Security**: Secure webhook endpoints with signatures and authentication
+
+## Webhook Events
+
+Admin.do supports webhooks for various events:
+
+### Function Events
+
+- `function.created`: A function was created
+- `function.updated`: A function was updated
+- `function.deleted`: A function was deleted
+- `function.executed`: A function was executed
+- `function.failed`: A function execution failed
+
+### Workflow Events
+
+- `workflow.created`: A workflow was created
+- `workflow.updated`: A workflow was updated
+- `workflow.deleted`: A workflow was deleted
+- `workflow.started`: A workflow was started
+- `workflow.completed`: A workflow was completed
+- `workflow.failed`: A workflow execution failed
+
+### Agent Events
+
+- `agent.created`: An agent was created
+- `agent.updated`: An agent was updated
+- `agent.deleted`: An agent was deleted
+- `agent.started`: An agent was started
+- `agent.completed`: An agent completed a task
+- `agent.failed`: An agent failed a task
+
+### Data Events
+
+- `data.created`: A data object was created
+- `data.updated`: A data object was updated
+- `data.deleted`: A data object was deleted
+
+### User Events
+
+- `user.created`: A user was created
+- `user.updated`: A user was updated
+- `user.deleted`: A user was deleted
+- `user.login`: A user logged in
+- `user.logout`: A user logged out
+
+### Organization Events
+
+- `organization.created`: An organization was created
+- `organization.updated`: An organization was updated
+- `organization.deleted`: An organization was deleted
+
+### Project Events
+
+- `project.created`: A project was created
+- `project.updated`: A project was updated
+- `project.deleted`: A project was deleted
+
+### Integration Events
+
+- `integration.created`: An integration was created
+- `integration.updated`: An integration was updated
+- `integration.deleted`: An integration was deleted
+- `integration.connected`: An integration was connected
+- `integration.disconnected`: An integration was disconnected
+
+### Billing Events
+
+- `billing.subscription.created`: A subscription was created
+- `billing.subscription.updated`: A subscription was updated
+- `billing.subscription.deleted`: A subscription was deleted
+- `billing.invoice.created`: An invoice was created
+- `billing.invoice.paid`: An invoice was paid
+- `billing.invoice.failed`: An invoice payment failed
+
+## Creating Webhooks
+
+Create webhooks using the Admin.do API:
+
+```typescript
+// Create a webhook
+const webhook = await admin.webhooks.create({
+  name: 'My Webhook',
+  description: 'A webhook for my application',
+  organization: 'org-123',
+  url: 'https://example.com/webhook',
+  events: ['function.executed', 'workflow.completed', 'agent.completed'],
+  secret: 'my-webhook-secret',
+  enabled: true
+})
+```
+
+## Managing Webhooks
+
+Manage webhooks using the Admin.do API:
+
+```typescript
+// Get all webhooks
+const webhooks = await admin.webhooks.list({
+  organization: 'org-123',
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific webhook
+const webhook = await admin.webhooks.get('wh-123')
+
+// Update a webhook
+const updatedWebhook = await admin.webhooks.update('wh-123', {
+  name: 'My Updated Webhook',
+  description: 'An updated webhook for my application',
+  url: 'https://example.com/updated-webhook',
+  events: ['function.executed', 'workflow.completed', 'agent.completed', 'data.created'],
+  enabled: true
+})
+
+// Delete a webhook
+await admin.webhooks.delete('wh-123')
+
+// Enable a webhook
+await admin.webhooks.enable('wh-123')
+
+// Disable a webhook
+await admin.webhooks.disable('wh-123')
+
+// Rotate webhook secret
+const newSecret = await admin.webhooks.rotateSecret('wh-123')
+```
+
+## Webhook Deliveries
+
+View webhook deliveries using the Admin.do API:
+
+```typescript
+// Get webhook deliveries
+const deliveries = await admin.webhooks.getDeliveries('wh-123', {
+  timeRange: {
+    start: '2023-06-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  status: 'success',
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific delivery
+const delivery = await admin.webhooks.getDelivery('wh-123', 'del-123')
+
+// Retry a delivery
+await admin.webhooks.retryDelivery('wh-123', 'del-123')
+```
+
+## Webhook Payload
+
+Webhook payloads include information about the event and the resource that triggered the event:
+
+```json
+{
+  "id": "evt-123",
+  "type": "function.executed",
+  "created": "2023-06-15T12:34:56Z",
+  "organization": "org-123",
+  "project": "proj-123",
+  "data": {
+    "id": "func-123",
+    "name": "My Function",
+    "execution": {
+      "id": "exec-123",
+      "status": "success",
+      "startTime": "2023-06-15T12:34:50Z",
+      "endTime": "2023-06-15T12:34:56Z",
+      "input": {
+        "name": "John"
+      },
+      "output": {
+        "greeting": "Hello, John!"
+      }
+    }
+  }
+}
+```
+
+## Webhook Security
+
+Secure your webhook endpoints by verifying the webhook signature:
+
+```typescript
+// Node.js example
+const crypto = require('crypto')
+const express = require('express')
+const app = express()
+
+app.use(express.json())
+
+app.post('/webhook', (req, res) => {
+  const signature = req.headers['x-admin-signature']
+  const timestamp = req.headers['x-admin-timestamp']
+  const webhookSecret = 'my-webhook-secret'
+  
+  // Create the signature
+  const payload = timestamp + '.' + JSON.stringify(req.body)
+  const expectedSignature = crypto
+    .createHmac('sha256', webhookSecret)
+    .update(payload)
+    .digest('hex')
+  
+  // Verify the signature
+  if (signature !== expectedSignature) {
+    return res.status(401).send('Invalid signature')
+  }
+  
+  // Verify the timestamp is recent (within 5 minutes)
+  const timestampDate = new Date(parseInt(timestamp))
+  const now = new Date()
+  const fiveMinutesAgo = new Date(now.getTime() - 5 * 60 * 1000)
+  
+  if (timestampDate < fiveMinutesAgo) {
+    return res.status(401).send('Timestamp too old')
+  }
+  
+  // Process the webhook
+  const event = req.body
+  console.log(`Received event: ${event.type}`)
+  
+  // Handle the event based on its type
+  switch (event.type) {
+    case 'function.executed':
+      // Handle function execution
+      break
+    case 'workflow.completed':
+      // Handle workflow completion
+      break
+    case 'agent.completed':
+      // Handle agent completion
+      break
+    default:
+      // Handle unknown event type
+      break
+  }
+  
+  // Acknowledge receipt of the webhook
+  res.status(200).send('Webhook received')
+})
+
+app.listen(3000, () => {
+  console.log('Webhook server listening on port 3000')
+})
+```
+
+## Webhook Testing
+
+Test webhooks using the Admin.do API:
+
+```typescript
+// Test a webhook
+const testResult = await admin.webhooks.test('wh-123', {
+  event: 'function.executed',
+  data: {
+    id: 'func-123',
+    name: 'My Function',
+    execution: {
+      id: 'exec-123',
+      status: 'success',
+      startTime: '2023-06-15T12:34:50Z',
+      endTime: '2023-06-15T12:34:56Z',
+      input: {
+        name: 'John'
+      },
+      output: {
+        greeting: 'Hello, John!'
+      }
+    }
+  }
+})
+```
+
+## Webhook Filters
+
+Filter webhook events using the Admin.do API:
+
+```typescript
+// Create a webhook with filters
+const webhook = await admin.webhooks.create({
+  name: 'My Filtered Webhook',
+  description: 'A webhook with filters',
+  organization: 'org-123',
+  url: 'https://example.com/webhook',
+  events: ['function.executed'],
+  filters: {
+    'function.executed': {
+      function: {
+        id: ['func-123', 'func-456'],
+        name: {
+          startsWith: 'My'
+        }
+      },
+      execution: {
+        status: ['success']
+      }
+    }
+  },
+  secret: 'my-webhook-secret',
+  enabled: true
+})
+
+// Update webhook filters
+const updatedWebhook = await admin.webhooks.updateFilters('wh-123', {
+  'function.executed': {
+    function: {
+      id: ['func-123', 'func-456', 'func-789'],
+      name: {
+        startsWith: 'My'
+      }
+    },
+    execution: {
+      status: ['success', 'error']
+    }
+  }
+})
+```
+
+## Next Steps
+
+- [Set up your first webhook](/admin/webhooks/setup)
+- [Secure your webhook endpoints](/admin/webhooks/security)
+- [Handle webhook events](/admin/webhooks/events)

--- a/content/evals/_meta.js
+++ b/content/evals/_meta.js
@@ -1,0 +1,30 @@
+export default {
+  index: {
+    title: 'Evals Overview',
+    type: 'page',
+  },
+  metrics: {
+    title: 'Metrics',
+    type: 'page',
+  },
+  tests: {
+    title: 'Tests',
+    type: 'page',
+  },
+  benchmarks: {
+    title: 'Benchmarks',
+    type: 'page',
+  },
+  datasets: {
+    title: 'Datasets',
+    type: 'page',
+  },
+  runs: {
+    title: 'Runs',
+    type: 'page',
+  },
+  results: {
+    title: 'Results',
+    type: 'page',
+  },
+}

--- a/content/evals/datasets.mdx
+++ b/content/evals/datasets.mdx
@@ -1,0 +1,607 @@
+# Datasets
+
+Create, manage, and use datasets for evaluating AI models and functions.
+
+## Overview
+
+Datasets provide a way to create, manage, and use collections of data for evaluating AI models and functions. Datasets can:
+
+- Store examples for testing and evaluation
+- Provide ground truth for benchmarking
+- Support different data types and formats
+- Enable reproducible evaluations
+
+## Key Features
+
+- **Data Management**: Create, update, and delete datasets
+- **Version Control**: Track changes to datasets over time
+- **Data Validation**: Validate data against schemas
+- **Data Transformation**: Transform data for different use cases
+- **Data Sharing**: Share datasets with teams and organizations
+
+## Dataset Types
+
+Evals.do supports various dataset types:
+
+### Text Datasets
+
+Text datasets contain text examples for natural language processing tasks:
+
+```typescript
+// Example text dataset
+const textDataset = {
+  id: 'ds-123',
+  name: 'Text Classification Dataset',
+  description: 'A dataset for text classification',
+  type: 'text',
+  schema: {
+    input: {
+      text: {
+        type: 'string',
+        description: 'The text to classify'
+      }
+    },
+    output: {
+      category: {
+        type: 'string',
+        description: 'The category of the text',
+        enum: ['positive', 'negative', 'neutral']
+      }
+    }
+  },
+  examples: [
+    {
+      input: {
+        text: 'I love this product!'
+      },
+      output: {
+        category: 'positive'
+      }
+    },
+    {
+      input: {
+        text: 'This product is terrible.'
+      },
+      output: {
+        category: 'negative'
+      }
+    },
+    {
+      input: {
+        text: 'The product works as expected.'
+      },
+      output: {
+        category: 'neutral'
+      }
+    }
+  ]
+}
+```
+
+### Image Datasets
+
+Image datasets contain image examples for computer vision tasks:
+
+```typescript
+// Example image dataset
+const imageDataset = {
+  id: 'ds-456',
+  name: 'Image Classification Dataset',
+  description: 'A dataset for image classification',
+  type: 'image',
+  schema: {
+    input: {
+      image: {
+        type: 'string',
+        format: 'uri',
+        description: 'The image to classify'
+      }
+    },
+    output: {
+      category: {
+        type: 'string',
+        description: 'The category of the image',
+        enum: ['cat', 'dog', 'other']
+      }
+    }
+  },
+  examples: [
+    {
+      input: {
+        image: 'https://example.com/images/cat1.jpg'
+      },
+      output: {
+        category: 'cat'
+      }
+    },
+    {
+      input: {
+        image: 'https://example.com/images/dog1.jpg'
+      },
+      output: {
+        category: 'dog'
+      }
+    },
+    {
+      input: {
+        image: 'https://example.com/images/bird1.jpg'
+      },
+      output: {
+        category: 'other'
+      }
+    }
+  ]
+}
+```
+
+### Structured Datasets
+
+Structured datasets contain structured data examples for various tasks:
+
+```typescript
+// Example structured dataset
+const structuredDataset = {
+  id: 'ds-789',
+  name: 'Customer Churn Dataset',
+  description: 'A dataset for predicting customer churn',
+  type: 'structured',
+  schema: {
+    input: {
+      customer: {
+        type: 'object',
+        properties: {
+          age: {
+            type: 'number',
+            description: 'The age of the customer'
+          },
+          tenure: {
+            type: 'number',
+            description: 'The number of months the customer has been with the company'
+          },
+          monthlyCharges: {
+            type: 'number',
+            description: 'The monthly charges for the customer'
+          },
+          totalCharges: {
+            type: 'number',
+            description: 'The total charges for the customer'
+          },
+          gender: {
+            type: 'string',
+            description: 'The gender of the customer',
+            enum: ['male', 'female']
+          },
+          hasPhoneService: {
+            type: 'boolean',
+            description: 'Whether the customer has phone service'
+          },
+          hasInternetService: {
+            type: 'boolean',
+            description: 'Whether the customer has internet service'
+          }
+        }
+      }
+    },
+    output: {
+      churn: {
+        type: 'boolean',
+        description: 'Whether the customer churned'
+      }
+    }
+  },
+  examples: [
+    {
+      input: {
+        customer: {
+          age: 45,
+          tenure: 24,
+          monthlyCharges: 65.5,
+          totalCharges: 1572.0,
+          gender: 'male',
+          hasPhoneService: true,
+          hasInternetService: true
+        }
+      },
+      output: {
+        churn: false
+      }
+    },
+    {
+      input: {
+        customer: {
+          age: 32,
+          tenure: 3,
+          monthlyCharges: 75.0,
+          totalCharges: 225.0,
+          gender: 'female',
+          hasPhoneService: true,
+          hasInternetService: true
+        }
+      },
+      output: {
+        churn: true
+      }
+    }
+  ]
+}
+```
+
+### Conversation Datasets
+
+Conversation datasets contain conversation examples for dialogue tasks:
+
+```typescript
+// Example conversation dataset
+const conversationDataset = {
+  id: 'ds-101',
+  name: 'Customer Support Dataset',
+  description: 'A dataset for customer support conversations',
+  type: 'conversation',
+  schema: {
+    input: {
+      conversation: {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            role: {
+              type: 'string',
+              description: 'The role of the speaker',
+              enum: ['user', 'assistant']
+            },
+            content: {
+              type: 'string',
+              description: 'The content of the message'
+            }
+          }
+        }
+      }
+    },
+    output: {
+      response: {
+        type: 'string',
+        description: 'The assistant response'
+      },
+      category: {
+        type: 'string',
+        description: 'The category of the conversation',
+        enum: ['billing', 'technical', 'account', 'general']
+      }
+    }
+  },
+  examples: [
+    {
+      input: {
+        conversation: [
+          {
+            role: 'user',
+            content: 'I can\'t log in to my account.'
+          },
+          {
+            role: 'assistant',
+            content: 'I\'m sorry to hear that. Can you tell me what error message you\'re seeing?'
+          },
+          {
+            role: 'user',
+            content: 'It says "Invalid username or password".'
+          }
+        ]
+      },
+      output: {
+        response: 'Thank you for providing that information. Let\'s try to reset your password. Can you confirm the email address associated with your account?',
+        category: 'account'
+      }
+    }
+  ]
+}
+```
+
+## Creating Datasets
+
+Create datasets using the Evals.do API:
+
+```typescript
+// Create a dataset
+const dataset = await evals.datasets.create({
+  name: 'Text Classification Dataset',
+  description: 'A dataset for text classification',
+  type: 'text',
+  schema: {
+    input: {
+      text: {
+        type: 'string',
+        description: 'The text to classify'
+      }
+    },
+    output: {
+      category: {
+        type: 'string',
+        description: 'The category of the text',
+        enum: ['positive', 'negative', 'neutral']
+      }
+    }
+  }
+})
+
+// Add examples to the dataset
+await evals.datasets.addExamples(dataset.id, [
+  {
+    input: {
+      text: 'I love this product!'
+    },
+    output: {
+      category: 'positive'
+    }
+  },
+  {
+    input: {
+      text: 'This product is terrible.'
+    },
+    output: {
+      category: 'negative'
+    }
+  },
+  {
+    input: {
+      text: 'The product works as expected.'
+    },
+    output: {
+      category: 'neutral'
+    }
+  }
+])
+```
+
+## Managing Datasets
+
+Manage datasets using the Evals.do API:
+
+```typescript
+// Get all datasets
+const datasets = await evals.datasets.list({
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific dataset
+const dataset = await evals.datasets.get('ds-123')
+
+// Update a dataset
+const updatedDataset = await evals.datasets.update('ds-123', {
+  name: 'Updated Text Classification Dataset',
+  description: 'An updated dataset for text classification'
+})
+
+// Delete a dataset
+await evals.datasets.delete('ds-123')
+
+// Get dataset examples
+const examples = await evals.datasets.getExamples('ds-123', {
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific example
+const example = await evals.datasets.getExample('ds-123', 'ex-123')
+
+// Update an example
+const updatedExample = await evals.datasets.updateExample('ds-123', 'ex-123', {
+  input: {
+    text: 'I absolutely love this product!'
+  },
+  output: {
+    category: 'positive'
+  }
+})
+
+// Delete an example
+await evals.datasets.deleteExample('ds-123', 'ex-123')
+```
+
+## Dataset Versions
+
+Manage dataset versions using the Evals.do API:
+
+```typescript
+// Create a new version of a dataset
+const newVersion = await evals.datasets.createVersion('ds-123', {
+  name: 'v2',
+  description: 'Version 2 of the dataset'
+})
+
+// Get all versions of a dataset
+const versions = await evals.datasets.listVersions('ds-123')
+
+// Get a specific version of a dataset
+const version = await evals.datasets.getVersion('ds-123', 'v2')
+
+// Update a version of a dataset
+const updatedVersion = await evals.datasets.updateVersion('ds-123', 'v2', {
+  description: 'Updated version 2 of the dataset'
+})
+
+// Delete a version of a dataset
+await evals.datasets.deleteVersion('ds-123', 'v2')
+
+// Get examples for a specific version of a dataset
+const examples = await evals.datasets.getVersionExamples('ds-123', 'v2', {
+  limit: 10,
+  offset: 0
+})
+```
+
+## Dataset Splits
+
+Manage dataset splits using the Evals.do API:
+
+```typescript
+// Create dataset splits
+const splits = await evals.datasets.createSplits('ds-123', {
+  train: 0.7,
+  validation: 0.15,
+  test: 0.15,
+  seed: 42
+})
+
+// Get dataset splits
+const splits = await evals.datasets.getSplits('ds-123')
+
+// Get examples for a specific split
+const trainExamples = await evals.datasets.getSplitExamples('ds-123', 'train', {
+  limit: 10,
+  offset: 0
+})
+
+// Update dataset splits
+const updatedSplits = await evals.datasets.updateSplits('ds-123', {
+  train: 0.8,
+  validation: 0.1,
+  test: 0.1,
+  seed: 42
+})
+
+// Delete dataset splits
+await evals.datasets.deleteSplits('ds-123')
+```
+
+## Dataset Import/Export
+
+Import and export datasets using the Evals.do API:
+
+```typescript
+// Import a dataset from a file
+const importedDataset = await evals.datasets.import({
+  name: 'Imported Dataset',
+  description: 'A dataset imported from a file',
+  file: '/path/to/dataset.json',
+  format: 'json'
+})
+
+// Import a dataset from a URL
+const importedDataset = await evals.datasets.importFromUrl({
+  name: 'Imported Dataset',
+  description: 'A dataset imported from a URL',
+  url: 'https://example.com/dataset.json',
+  format: 'json'
+})
+
+// Export a dataset to a file
+await evals.datasets.export('ds-123', {
+  format: 'json',
+  path: '/path/to/export.json'
+})
+
+// Export a dataset to a URL
+const exportUrl = await evals.datasets.exportToUrl('ds-123', {
+  format: 'json'
+})
+```
+
+## Dataset Transformations
+
+Transform datasets using the Evals.do API:
+
+```typescript
+// Filter a dataset
+const filteredDataset = await evals.datasets.filter('ds-123', {
+  name: 'Filtered Dataset',
+  description: 'A filtered version of the dataset',
+  filter: {
+    'output.category': 'positive'
+  }
+})
+
+// Sample a dataset
+const sampledDataset = await evals.datasets.sample('ds-123', {
+  name: 'Sampled Dataset',
+  description: 'A sampled version of the dataset',
+  size: 100,
+  seed: 42
+})
+
+// Merge datasets
+const mergedDataset = await evals.datasets.merge({
+  name: 'Merged Dataset',
+  description: 'A merged dataset',
+  datasets: ['ds-123', 'ds-456']
+})
+
+// Transform a dataset
+const transformedDataset = await evals.datasets.transform('ds-123', {
+  name: 'Transformed Dataset',
+  description: 'A transformed version of the dataset',
+  transformations: [
+    {
+      type: 'map',
+      field: 'input.text',
+      function: 'text => text.toLowerCase()'
+    },
+    {
+      type: 'filter',
+      function: 'example => example.output.category !== "neutral"'
+    }
+  ]
+})
+```
+
+## Dataset Statistics
+
+Get dataset statistics using the Evals.do API:
+
+```typescript
+// Get dataset statistics
+const statistics = await evals.datasets.getStatistics('ds-123')
+
+// Get statistics for a specific field
+const fieldStatistics = await evals.datasets.getFieldStatistics('ds-123', 'output.category')
+
+// Get dataset distribution
+const distribution = await evals.datasets.getDistribution('ds-123', 'output.category')
+
+// Get dataset correlations
+const correlations = await evals.datasets.getCorrelations('ds-123')
+```
+
+## Dataset Sharing
+
+Share datasets using the Evals.do API:
+
+```typescript
+// Share a dataset with a user
+await evals.datasets.share('ds-123', {
+  user: 'user-123',
+  permission: 'read'
+})
+
+// Share a dataset with a team
+await evals.datasets.share('ds-123', {
+  team: 'team-123',
+  permission: 'write'
+})
+
+// Share a dataset with an organization
+await evals.datasets.share('ds-123', {
+  organization: 'org-123',
+  permission: 'admin'
+})
+
+// Get dataset permissions
+const permissions = await evals.datasets.getPermissions('ds-123')
+
+// Update dataset permissions
+await evals.datasets.updatePermissions('ds-123', {
+  user: 'user-123',
+  permission: 'write'
+})
+
+// Remove dataset permissions
+await evals.datasets.removePermissions('ds-123', {
+  user: 'user-123'
+})
+```
+
+## Next Steps
+
+- [Create your first dataset](/evals/datasets/create)
+- [Import data from external sources](/evals/datasets/import)
+- [Use datasets in evaluations](/evals/datasets/evaluations)

--- a/content/evals/results.mdx
+++ b/content/evals/results.mdx
@@ -1,0 +1,546 @@
+# Evaluation Results
+
+Analyze and interpret the results of AI model and function evaluations.
+
+## Overview
+
+Evaluation Results provide a way to analyze and interpret the outcomes of AI model and function evaluations. Evaluation Results can:
+
+- Provide performance metrics
+- Show detailed example-level results
+- Enable result filtering and aggregation
+- Support visualization and reporting
+
+## Key Features
+
+- **Performance Metrics**: View and analyze performance metrics
+- **Example-Level Results**: Examine detailed results for individual examples
+- **Result Filtering**: Filter results based on various criteria
+- **Result Aggregation**: Aggregate results across different dimensions
+- **Visualization**: Visualize results with charts and graphs
+
+## Accessing Evaluation Results
+
+Access evaluation results using the Evals.do API:
+
+```typescript
+// Get all evaluation results
+const results = await evals.results.list({
+  limit: 10,
+  offset: 0
+})
+
+// Get results for a specific evaluation run
+const runResults = await evals.results.getByRun('run-123')
+
+// Get a specific result
+const result = await evals.results.get('result-123')
+
+// Get results for a specific target (function, workflow, or agent)
+const targetResults = await evals.results.getByTarget({
+  type: 'function',
+  id: 'func-123'
+})
+
+// Get results for a specific dataset
+const datasetResults = await evals.results.getByDataset('ds-123')
+
+// Get results for a specific evaluation
+const evalResults = await evals.results.getByEval('eval-123')
+```
+
+## Result Metrics
+
+Access result metrics using the Evals.do API:
+
+```typescript
+// Get metrics for a specific result
+const metrics = await evals.results.getMetrics('result-123')
+
+// Get metrics for a specific evaluation run
+const runMetrics = await evals.results.getRunMetrics('run-123')
+
+// Get metrics for a specific target
+const targetMetrics = await evals.results.getTargetMetrics({
+  type: 'function',
+  id: 'func-123'
+})
+
+// Get metrics for a specific dataset
+const datasetMetrics = await evals.results.getDatasetMetrics('ds-123')
+
+// Get metrics for a specific evaluation
+const evalMetrics = await evals.results.getEvalMetrics('eval-123')
+
+// Get metrics over time
+const metricsOverTime = await evals.results.getMetricsOverTime({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  timeRange: {
+    start: '2023-01-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  interval: 'month'
+})
+```
+
+## Example-Level Results
+
+Access example-level results using the Evals.do API:
+
+```typescript
+// Get examples for a specific result
+const examples = await evals.results.getExamples('result-123', {
+  limit: 10,
+  offset: 0
+})
+
+// Get examples for a specific evaluation run
+const runExamples = await evals.results.getRunExamples('run-123', {
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific example result
+const example = await evals.results.getExample('result-123', 'ex-123')
+
+// Get examples with errors
+const errorExamples = await evals.results.getErrorExamples('result-123', {
+  limit: 10,
+  offset: 0
+})
+
+// Get examples with low scores
+const lowScoreExamples = await evals.results.getLowScoreExamples('result-123', {
+  metric: 'accuracy',
+  threshold: 0.5,
+  limit: 10,
+  offset: 0
+})
+
+// Get examples with high scores
+const highScoreExamples = await evals.results.getHighScoreExamples('result-123', {
+  metric: 'accuracy',
+  threshold: 0.9,
+  limit: 10,
+  offset: 0
+})
+```
+
+## Result Filtering
+
+Filter results using the Evals.do API:
+
+```typescript
+// Filter results by criteria
+const filteredResults = await evals.results.filter({
+  runs: ['run-123', 'run-456'],
+  targets: [
+    {
+      type: 'function',
+      id: 'func-123'
+    },
+    {
+      type: 'function',
+      id: 'func-456'
+    }
+  ],
+  datasets: ['ds-123', 'ds-456'],
+  evals: ['eval-123', 'eval-456'],
+  metrics: {
+    accuracy: {
+      min: 0.8,
+      max: 1.0
+    },
+    f1_score: {
+      min: 0.7
+    }
+  },
+  timeRange: {
+    start: '2023-01-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  limit: 10,
+  offset: 0
+})
+
+// Filter examples by criteria
+const filteredExamples = await evals.results.filterExamples('result-123', {
+  metrics: {
+    accuracy: {
+      min: 0.8,
+      max: 1.0
+    }
+  },
+  input: {
+    text: {
+      contains: 'product'
+    }
+  },
+  output: {
+    category: ['positive', 'negative']
+  },
+  prediction: {
+    category: ['positive']
+  },
+  limit: 10,
+  offset: 0
+})
+```
+
+## Result Aggregation
+
+Aggregate results using the Evals.do API:
+
+```typescript
+// Aggregate results by dimension
+const aggregatedResults = await evals.results.aggregate({
+  runs: ['run-123', 'run-456'],
+  groupBy: ['target', 'dataset'],
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  timeRange: {
+    start: '2023-01-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  }
+})
+
+// Aggregate examples by dimension
+const aggregatedExamples = await evals.results.aggregateExamples('result-123', {
+  groupBy: ['output.category', 'prediction.category'],
+  metrics: ['accuracy', 'f1_score']
+})
+
+// Get confusion matrix
+const confusionMatrix = await evals.results.getConfusionMatrix('result-123', {
+  actual: 'output.category',
+  predicted: 'prediction.category'
+})
+
+// Get distribution of predictions
+const predictionDistribution = await evals.results.getPredictionDistribution('result-123', {
+  field: 'prediction.category'
+})
+
+// Get distribution of errors
+const errorDistribution = await evals.results.getErrorDistribution('result-123', {
+  groupBy: 'output.category'
+})
+```
+
+## Result Comparison
+
+Compare results using the Evals.do API:
+
+```typescript
+// Compare results
+const comparison = await evals.results.compare(['result-123', 'result-456'])
+
+// Compare metrics
+const metricComparison = await evals.results.compareMetrics(['result-123', 'result-456'], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+})
+
+// Compare examples
+const exampleComparison = await evals.results.compareExamples(['result-123', 'result-456'], {
+  limit: 10,
+  offset: 0
+})
+
+// Compare targets
+const targetComparison = await evals.results.compareTargets([
+  {
+    type: 'function',
+    id: 'func-123'
+  },
+  {
+    type: 'function',
+    id: 'func-456'
+  }
+], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  dataset: 'ds-123'
+})
+
+// Compare datasets
+const datasetComparison = await evals.results.compareDatasets(['ds-123', 'ds-456'], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  target: {
+    type: 'function',
+    id: 'func-123'
+  }
+})
+
+// Compare evaluations
+const evalComparison = await evals.results.compareEvals(['eval-123', 'eval-456'], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  dataset: 'ds-123'
+})
+```
+
+## Result Visualization
+
+Visualize results using the Evals.do API:
+
+```typescript
+// Generate a metric chart
+const metricChart = await evals.results.generateMetricChart('result-123', {
+  metric: 'accuracy',
+  type: 'bar',
+  groupBy: 'output.category'
+})
+
+// Generate a comparison chart
+const comparisonChart = await evals.results.generateComparisonChart(['result-123', 'result-456'], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  type: 'radar'
+})
+
+// Generate a confusion matrix chart
+const confusionMatrixChart = await evals.results.generateConfusionMatrixChart('result-123', {
+  actual: 'output.category',
+  predicted: 'prediction.category',
+  normalized: true
+})
+
+// Generate a distribution chart
+const distributionChart = await evals.results.generateDistributionChart('result-123', {
+  field: 'prediction.category',
+  type: 'pie'
+})
+
+// Generate a metrics over time chart
+const metricsOverTimeChart = await evals.results.generateMetricsOverTimeChart({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  metrics: ['accuracy', 'f1_score'],
+  timeRange: {
+    start: '2023-01-01T00:00:00Z',
+    end: '2023-06-30T23:59:59Z'
+  },
+  interval: 'month',
+  type: 'line'
+})
+```
+
+## Result Reporting
+
+Generate reports using the Evals.do API:
+
+```typescript
+// Generate a result report
+const reportUrl = await evals.results.generateReport('result-123', {
+  format: 'pdf',
+  includeExamples: true,
+  includeMetrics: true,
+  includeCharts: true,
+  title: 'Evaluation Result Report',
+  description: 'A report of evaluation results'
+})
+
+// Generate a comparison report
+const comparisonReportUrl = await evals.results.generateComparisonReport(['result-123', 'result-456'], {
+  format: 'pdf',
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  includeExamples: true,
+  includeCharts: true,
+  title: 'Evaluation Comparison Report',
+  description: 'A comparison of evaluation results'
+})
+
+// Schedule a recurring report
+await evals.results.scheduleReport({
+  name: 'Monthly Evaluation Report',
+  description: 'A monthly report of evaluation results',
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  format: 'pdf',
+  includeExamples: true,
+  includeMetrics: true,
+  includeCharts: true,
+  schedule: {
+    frequency: 'monthly',
+    day: 1,
+    time: '00:00:00Z'
+  },
+  recipients: ['user1@example.com', 'user2@example.com']
+})
+
+// Get all scheduled reports
+const scheduledReports = await evals.results.listScheduledReports({
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific scheduled report
+const scheduledReport = await evals.results.getScheduledReport('report-123')
+
+// Update a scheduled report
+const updatedScheduledReport = await evals.results.updateScheduledReport('report-123', {
+  name: 'Updated Monthly Evaluation Report',
+  description: 'An updated monthly report of evaluation results',
+  recipients: ['user1@example.com', 'user2@example.com', 'user3@example.com']
+})
+
+// Delete a scheduled report
+await evals.results.deleteScheduledReport('report-123')
+```
+
+## Result Notifications
+
+Configure result notifications using the Evals.do API:
+
+```typescript
+// Configure result notifications
+await evals.results.configureNotifications({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  conditions: [
+    {
+      metric: 'accuracy',
+      operator: 'lt',
+      value: 0.9,
+      name: 'Low Accuracy Alert'
+    },
+    {
+      metric: 'error_rate',
+      operator: 'gt',
+      value: 0.1,
+      name: 'High Error Rate Alert'
+    }
+  ],
+  channels: {
+    email: ['user1@example.com', 'user2@example.com'],
+    slack: ['#alerts']
+  }
+})
+
+// Get result notification configuration
+const notifications = await evals.results.getNotifications({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  }
+})
+
+// Update result notification configuration
+await evals.results.updateNotifications({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  conditions: [
+    {
+      metric: 'accuracy',
+      operator: 'lt',
+      value: 0.85,
+      name: 'Low Accuracy Alert'
+    },
+    {
+      metric: 'error_rate',
+      operator: 'gt',
+      value: 0.15,
+      name: 'High Error Rate Alert'
+    }
+  ],
+  channels: {
+    email: ['user1@example.com', 'user2@example.com', 'user3@example.com'],
+    slack: ['#alerts', '#monitoring']
+  }
+})
+
+// Delete result notification configuration
+await evals.results.deleteNotifications({
+  target: {
+    type: 'function',
+    id: 'func-123'
+  }
+})
+```
+
+## Result Exports
+
+Export results using the Evals.do API:
+
+```typescript
+// Export results
+const exportUrl = await evals.results.export('result-123', {
+  format: 'json',
+  includeExamples: true,
+  includeMetrics: true
+})
+
+// Export comparison
+const comparisonExportUrl = await evals.results.exportComparison(['result-123', 'result-456'], {
+  format: 'csv',
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+})
+
+// Export examples
+const examplesExportUrl = await evals.results.exportExamples('result-123', {
+  format: 'json',
+  limit: 1000
+})
+
+// Export metrics
+const metricsExportUrl = await evals.results.exportMetrics('result-123', {
+  format: 'csv',
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+})
+```
+
+## Result Sharing
+
+Share results using the Evals.do API:
+
+```typescript
+// Share a result with a user
+await evals.results.share('result-123', {
+  user: 'user-123',
+  permission: 'read'
+})
+
+// Share a result with a team
+await evals.results.share('result-123', {
+  team: 'team-123',
+  permission: 'write'
+})
+
+// Share a result with an organization
+await evals.results.share('result-123', {
+  organization: 'org-123',
+  permission: 'admin'
+})
+
+// Get result permissions
+const permissions = await evals.results.getPermissions('result-123')
+
+// Update result permissions
+await evals.results.updatePermissions('result-123', {
+  user: 'user-123',
+  permission: 'write'
+})
+
+// Remove result permissions
+await evals.results.removePermissions('result-123', {
+  user: 'user-123'
+})
+```
+
+## Next Steps
+
+- [Analyze your first evaluation results](/evals/results/analysis)
+- [Compare model performance](/evals/results/comparison)
+- [Create custom visualizations](/evals/results/visualization)

--- a/content/evals/runs.mdx
+++ b/content/evals/runs.mdx
@@ -1,0 +1,365 @@
+# Evaluation Runs
+
+Execute and manage evaluation runs to assess the performance of AI models and functions.
+
+## Overview
+
+Evaluation Runs provide a way to execute and manage evaluations of AI models and functions. Evaluation Runs can:
+
+- Execute evaluations on models and functions
+- Track evaluation progress and status
+- Collect evaluation results
+- Compare performance across different models and functions
+
+## Key Features
+
+- **Evaluation Execution**: Execute evaluations on models and functions
+- **Progress Tracking**: Track evaluation progress and status
+- **Result Collection**: Collect evaluation results
+- **Performance Comparison**: Compare performance across different models and functions
+
+## Creating Evaluation Runs
+
+Create evaluation runs using the Evals.do API:
+
+```typescript
+// Create an evaluation run
+const run = await evals.runs.create({
+  name: 'Text Classification Evaluation',
+  description: 'Evaluating text classification models',
+  eval: 'eval-123', // Reference to the evaluation configuration
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  dataset: 'ds-123',
+  parameters: {
+    batchSize: 32,
+    maxExamples: 1000
+  }
+})
+```
+
+## Managing Evaluation Runs
+
+Manage evaluation runs using the Evals.do API:
+
+```typescript
+// Get all evaluation runs
+const runs = await evals.runs.list({
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific evaluation run
+const run = await evals.runs.get('run-123')
+
+// Update an evaluation run
+const updatedRun = await evals.runs.update('run-123', {
+  name: 'Updated Text Classification Evaluation',
+  description: 'Updated evaluation of text classification models'
+})
+
+// Delete an evaluation run
+await evals.runs.delete('run-123')
+```
+
+## Controlling Evaluation Runs
+
+Control evaluation runs using the Evals.do API:
+
+```typescript
+// Start an evaluation run
+await evals.runs.start('run-123')
+
+// Pause an evaluation run
+await evals.runs.pause('run-123')
+
+// Resume an evaluation run
+await evals.runs.resume('run-123')
+
+// Cancel an evaluation run
+await evals.runs.cancel('run-123')
+
+// Restart an evaluation run
+await evals.runs.restart('run-123')
+```
+
+## Evaluation Run Status
+
+Get evaluation run status using the Evals.do API:
+
+```typescript
+// Get evaluation run status
+const status = await evals.runs.getStatus('run-123')
+
+// Get evaluation run progress
+const progress = await evals.runs.getProgress('run-123')
+
+// Get evaluation run logs
+const logs = await evals.runs.getLogs('run-123', {
+  limit: 10,
+  offset: 0
+})
+```
+
+## Evaluation Run Results
+
+Get evaluation run results using the Evals.do API:
+
+```typescript
+// Get evaluation run results
+const results = await evals.runs.getResults('run-123')
+
+// Get evaluation run metrics
+const metrics = await evals.runs.getMetrics('run-123')
+
+// Get evaluation run examples
+const examples = await evals.runs.getExamples('run-123', {
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific example result
+const example = await evals.runs.getExample('run-123', 'ex-123')
+```
+
+## Evaluation Run Comparison
+
+Compare evaluation runs using the Evals.do API:
+
+```typescript
+// Compare evaluation runs
+const comparison = await evals.runs.compare(['run-123', 'run-456'])
+
+// Compare evaluation run metrics
+const metricComparison = await evals.runs.compareMetrics(['run-123', 'run-456'], {
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+})
+
+// Compare evaluation run examples
+const exampleComparison = await evals.runs.compareExamples(['run-123', 'run-456'], {
+  limit: 10,
+  offset: 0
+})
+```
+
+## Evaluation Run Configuration
+
+Configure evaluation runs using the Evals.do API:
+
+```typescript
+// Create an evaluation run configuration
+const config = await evals.runs.createConfig({
+  name: 'Text Classification Config',
+  description: 'Configuration for text classification evaluations',
+  parameters: {
+    batchSize: 32,
+    maxExamples: 1000,
+    metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+  }
+})
+
+// Get all evaluation run configurations
+const configs = await evals.runs.listConfigs({
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific evaluation run configuration
+const config = await evals.runs.getConfig('config-123')
+
+// Update an evaluation run configuration
+const updatedConfig = await evals.runs.updateConfig('config-123', {
+  name: 'Updated Text Classification Config',
+  description: 'Updated configuration for text classification evaluations',
+  parameters: {
+    batchSize: 64,
+    maxExamples: 2000,
+    metrics: ['accuracy', 'f1_score', 'precision', 'recall', 'roc_auc']
+  }
+})
+
+// Delete an evaluation run configuration
+await evals.runs.deleteConfig('config-123')
+
+// Create an evaluation run from a configuration
+const run = await evals.runs.createFromConfig({
+  config: 'config-123',
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  dataset: 'ds-123'
+})
+```
+
+## Evaluation Run Scheduling
+
+Schedule evaluation runs using the Evals.do API:
+
+```typescript
+// Schedule an evaluation run
+const schedule = await evals.runs.schedule({
+  name: 'Scheduled Text Classification Evaluation',
+  description: 'Scheduled evaluation of text classification models',
+  eval: 'eval-123',
+  target: {
+    type: 'function',
+    id: 'func-123'
+  },
+  dataset: 'ds-123',
+  schedule: {
+    frequency: 'daily',
+    time: '00:00:00Z',
+    startDate: '2023-07-01',
+    endDate: '2023-12-31'
+  }
+})
+
+// Get all scheduled evaluation runs
+const schedules = await evals.runs.listSchedules({
+  limit: 10,
+  offset: 0
+})
+
+// Get a specific scheduled evaluation run
+const schedule = await evals.runs.getSchedule('sched-123')
+
+// Update a scheduled evaluation run
+const updatedSchedule = await evals.runs.updateSchedule('sched-123', {
+  name: 'Updated Scheduled Text Classification Evaluation',
+  description: 'Updated scheduled evaluation of text classification models',
+  schedule: {
+    frequency: 'weekly',
+    dayOfWeek: 'monday',
+    time: '00:00:00Z'
+  }
+})
+
+// Delete a scheduled evaluation run
+await evals.runs.deleteSchedule('sched-123')
+
+// Pause a scheduled evaluation run
+await evals.runs.pauseSchedule('sched-123')
+
+// Resume a scheduled evaluation run
+await evals.runs.resumeSchedule('sched-123')
+```
+
+## Evaluation Run Notifications
+
+Configure evaluation run notifications using the Evals.do API:
+
+```typescript
+// Configure evaluation run notifications
+await evals.runs.configureNotifications('run-123', {
+  onStart: {
+    email: ['user1@example.com', 'user2@example.com'],
+    slack: ['#evaluations']
+  },
+  onComplete: {
+    email: ['user1@example.com', 'user2@example.com', 'user3@example.com'],
+    slack: ['#evaluations', '#results']
+  },
+  onError: {
+    email: ['user1@example.com', 'admin@example.com'],
+    slack: ['#evaluations', '#alerts']
+  }
+})
+
+// Get evaluation run notification configuration
+const notifications = await evals.runs.getNotifications('run-123')
+
+// Update evaluation run notification configuration
+await evals.runs.updateNotifications('run-123', {
+  onComplete: {
+    email: ['user1@example.com', 'user2@example.com', 'user4@example.com'],
+    slack: ['#evaluations', '#results']
+  }
+})
+
+// Delete evaluation run notification configuration
+await evals.runs.deleteNotifications('run-123')
+```
+
+## Evaluation Run Exports
+
+Export evaluation run results using the Evals.do API:
+
+```typescript
+// Export evaluation run results
+const exportUrl = await evals.runs.export('run-123', {
+  format: 'json',
+  includeExamples: true,
+  includeMetrics: true,
+  includeLogs: false
+})
+
+// Export evaluation run comparison
+const comparisonExportUrl = await evals.runs.exportComparison(['run-123', 'run-456'], {
+  format: 'csv',
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall']
+})
+
+// Generate an evaluation run report
+const reportUrl = await evals.runs.generateReport('run-123', {
+  format: 'pdf',
+  includeExamples: true,
+  includeMetrics: true,
+  includeLogs: false,
+  includeCharts: true
+})
+
+// Generate an evaluation run comparison report
+const comparisonReportUrl = await evals.runs.generateComparisonReport(['run-123', 'run-456'], {
+  format: 'pdf',
+  metrics: ['accuracy', 'f1_score', 'precision', 'recall'],
+  includeExamples: true,
+  includeCharts: true
+})
+```
+
+## Evaluation Run Sharing
+
+Share evaluation runs using the Evals.do API:
+
+```typescript
+// Share an evaluation run with a user
+await evals.runs.share('run-123', {
+  user: 'user-123',
+  permission: 'read'
+})
+
+// Share an evaluation run with a team
+await evals.runs.share('run-123', {
+  team: 'team-123',
+  permission: 'write'
+})
+
+// Share an evaluation run with an organization
+await evals.runs.share('run-123', {
+  organization: 'org-123',
+  permission: 'admin'
+})
+
+// Get evaluation run permissions
+const permissions = await evals.runs.getPermissions('run-123')
+
+// Update evaluation run permissions
+await evals.runs.updatePermissions('run-123', {
+  user: 'user-123',
+  permission: 'write'
+})
+
+// Remove evaluation run permissions
+await evals.runs.removePermissions('run-123', {
+  user: 'user-123'
+})
+```
+
+## Next Steps
+
+- [Create your first evaluation run](/evals/runs/create)
+- [Configure evaluation parameters](/evals/runs/configuration)
+- [Analyze evaluation results](/evals/runs/analysis)


### PR DESCRIPTION
This PR adds missing documentation for webhooks, apikeys, and evals collections based on the collections structure in collections/index.ts.

## Changes

- Added documentation for webhooks in admin collection
- Added documentation for API keys in admin collection
- Added documentation for datasets, runs, and results in evals collection
- Updated _meta.js file for evals collection to include new pages

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/64c83f575df0448080c82de2079338eb)