### PR TITLE
Fix issue #140: Add relationTo property to ZapierCollectionConfig interface

### DIFF
--- a/integrations/zapier/src/types/collection.ts
+++ b/integrations/zapier/src/types/collection.ts
@@ -1,0 +1,52 @@
+/**
+ * Simplified interface for collection configuration used in Zapier templates
+ * This decouples the template code from specific Payload implementation details
+ */
+export interface ZapierCollectionConfig {
+  /**
+   * The slug of the collection
+   */
+  slug: string;
+  
+  /**
+   * The fields of the collection
+   */
+  fields?: ZapierField[];
+  
+  /**
+   * Admin configuration
+   */
+  admin?: {
+    useAsTitle?: string;
+  };
+}
+
+/**
+ * Simplified interface for field configuration used in Zapier templates
+ */
+export interface ZapierField {
+  /**
+   * The name of the field
+   */
+  name?: string;
+  
+  /**
+   * The type of the field
+   */
+  type?: string;
+  
+  /**
+   * Whether the field is required
+   */
+  required?: boolean;
+  
+  /**
+   * For relationship fields, the collection to relate to
+   */
+  relationTo?: string | string[];
+  
+  /**
+   * For array fields, the fields within the array
+   */
+  fields?: ZapierField[];
+}

--- a/integrations/zapier/test/mocks/payload.ts
+++ b/integrations/zapier/test/mocks/payload.ts
@@ -1,0 +1,19 @@
+// Mock for payload CollectionConfig type
+export interface CollectionConfig {
+  slug: string;
+  fields: Array<{
+    name: string;
+    type: string;
+    required?: boolean;
+    relationTo?: string | string[];
+    fields?: Array<{
+      name: string;
+      type: string;
+      required?: boolean;
+      relationTo?: string | string[];
+    }>;
+  }>;
+  admin?: {
+    useAsTitle?: string;
+  };
+}


### PR DESCRIPTION
This PR fixes issue #140 by adding a ZapierCollectionConfig interface with proper support for the relationTo property in field definitions. This ensures compatibility between the mock data used in tests and the actual Payload types.

Changes made:
1. Created a dedicated ZapierCollectionConfig interface with fields property as ZapierField[]
2. Created ZapierField interface with optional relationTo property
3. Updated the mock payload.ts file to include the relationTo property
4. Added proper JSDoc comments to interfaces

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/538eb8f00df141989bdd7feba2bc3bfb)