### PR TITLE
Fix Zapier app generation for relationship fields

### DIFF
--- a/integrations/zapier/src/generate.ts
+++ b/integrations/zapier/src/generate.ts
@@ -1,0 +1,167 @@
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+import { execSync } from 'child_process'
+import { generateAppTemplate } from './templates/app'
+import { generateAuthenticationTemplate } from './templates/authentication'
+import { generateCreateTemplate } from './templates/create'
+import { generateListTemplate } from './templates/list'
+import { generateGetTemplate } from './templates/get'
+import { generateUpdateTemplate } from './templates/update'
+import { generateDeleteTemplate } from './templates/delete'
+import { ZapierCollectionConfig } from './types/collection'
+import { camelCase, pascalCase, kebabCase } from './utils/stringUtils'
+
+// Get the current file's directory
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// Import collections dynamically
+async function getCollections() {
+  try {
+    // Dynamic import for ESM compatibility
+    const collectionsPath = path.resolve(__dirname, '../../../collections/index.js')
+    const collectionsModule = await import(collectionsPath)
+    return collectionsModule.collections || []
+  } catch (error) {
+    console.error('Error importing collections:', error)
+    return []
+  }
+}
+
+// Main function to generate Zapier apps
+async function main() {
+  try {
+    // Ensure output directories exist
+    const outputDir = path.resolve(__dirname, '../apps')
+    if (!fs.existsSync(outputDir)) {
+      fs.mkdirSync(outputDir, { recursive: true })
+    }
+
+    // Get collections
+    const collections = await getCollections()
+    
+    if (!collections || collections.length === 0) {
+      console.error('No collections found')
+      return
+    }
+    
+    console.log(`Found ${collections.length} collections`)
+
+    // Generate Zapier apps for each collection
+    for (const collection of collections) {
+      const collectionSlug = collection.slug
+      const collectionName = pascalCase(collectionSlug)
+      const collectionDir = path.resolve(outputDir, collectionSlug)
+      
+      // Create collection directory
+      if (!fs.existsSync(collectionDir)) {
+        fs.mkdirSync(collectionDir, { recursive: true })
+      }
+
+      // Create src directory
+      const srcDir = path.resolve(collectionDir, 'src')
+      if (!fs.existsSync(srcDir)) {
+        fs.mkdirSync(srcDir, { recursive: true })
+      }
+
+      // Create test directory
+      const testDir = path.resolve(collectionDir, 'test')
+      if (!fs.existsSync(testDir)) {
+        fs.mkdirSync(testDir, { recursive: true })
+      }
+
+      // Generate app.js
+      const appContent = generateAppTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'index.js'), appContent)
+
+      // Generate authentication.js
+      const authContent = generateAuthenticationTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'authentication.js'), authContent)
+
+      // Generate CRUD operations
+      const createContent = generateCreateTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'creates.js'), createContent)
+
+      const listContent = generateListTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'searches.js'), listContent)
+
+      const getContent = generateGetTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'gets.js'), getContent)
+
+      const updateContent = generateUpdateTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'updates.js'), updateContent)
+
+      const deleteContent = generateDeleteTemplate(collection)
+      fs.writeFileSync(path.resolve(srcDir, 'deletes.js'), deleteContent)
+
+      // Generate package.json
+      const packageJson = {
+        name: `ai-primitives-zapier-${collectionSlug}`,
+        version: '1.0.0',
+        description: `Zapier integration for AI Primitives ${collectionName}`,
+        main: 'src/index.js',
+        scripts: {
+          test: 'jest --testTimeout 10000',
+          build: 'tsc',
+          deploy: 'zapier push'
+        },
+        dependencies: {
+          'zapier-platform-core': '^15.5.1'
+        },
+        devDependencies: {
+          jest: '^29.7.0'
+        },
+        private: true
+      }
+
+      fs.writeFileSync(
+        path.resolve(collectionDir, 'package.json'),
+        JSON.stringify(packageJson, null, 2)
+      )
+
+      // Generate .gitignore
+      const gitignore = `
+# Logs
+logs
+*.log
+npm-debug.log*
+
+# Dependencies
+node_modules/
+
+# Build
+/lib
+
+# Misc
+.DS_Store
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+`
+      fs.writeFileSync(path.resolve(collectionDir, '.gitignore'), gitignore.trim())
+
+      // Generate .zapierapprc
+      const zapierAppRc = {
+        id: `ai-primitives-${collectionSlug}`,
+        key: `ai-primitives-${collectionSlug}`
+      }
+
+      fs.writeFileSync(
+        path.resolve(collectionDir, '.zapierapprc'),
+        JSON.stringify(zapierAppRc, null, 2)
+      )
+
+      console.log(`Generated Zapier app for ${collectionName}`)
+    }
+
+    console.log('All Zapier apps generated successfully!')
+  } catch (error) {
+    console.error('Error generating Zapier apps:', error)
+  }
+}
+
+// Run the main function
+main()

--- a/integrations/zapier/src/templates/app.ts
+++ b/integrations/zapier/src/templates/app.ts
@@ -1,0 +1,62 @@
+import { ZapierCollectionConfig } from '../types/collection'
+import { pascalCase, titleCase } from '../utils/stringUtils'
+
+/**
+ * Generates the main app.js file for a Zapier app
+ * @param collection The collection to generate the app for
+ * @returns The content of the app.js file
+ */
+export function generateAppTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+
+  return `// Generated Zapier App for ${collectionTitle}
+const authentication = require('./authentication');
+const creates = require('./creates');
+const searches = require('./searches');
+const gets = require('./gets');
+const updates = require('./updates');
+const deletes = require('./deletes');
+
+module.exports = {
+  version: require('../package.json').version,
+  platformVersion: require('zapier-platform-core').version,
+  
+  authentication,
+  
+  beforeRequest: [
+    (request, z, bundle) => {
+      // Add authentication headers
+      if (bundle.authData.apiKey) {
+        request.headers.Authorization = \`Bearer \${bundle.authData.apiKey}\`;
+      }
+      return request;
+    }
+  ],
+  
+  afterResponse: [
+    (response, z, bundle) => {
+      // Handle response errors
+      if (response.status >= 400) {
+        throw new Error(\`Unexpected status code \${response.status}\`);
+      }
+      return response;
+    }
+  ],
+  
+  resources: {},
+  
+  triggers: {},
+  
+  searches,
+  
+  creates,
+  
+  gets,
+  
+  updates,
+  
+  deletes,
+};
+`
+}

--- a/integrations/zapier/src/templates/authentication.ts
+++ b/integrations/zapier/src/templates/authentication.ts
@@ -1,0 +1,52 @@
+import { ZapierCollectionConfig } from '../types/collection'
+import { pascalCase, titleCase } from '../utils/stringUtils'
+
+/**
+ * Generates the authentication.js file for a Zapier app
+ * @param collection The collection to generate the authentication for
+ * @returns The content of the authentication.js file
+ */
+export function generateAuthenticationTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+
+  return `// Authentication for ${collectionTitle} Zapier App
+module.exports = {
+  type: 'custom',
+  
+  fields: [
+    {
+      key: 'apiKey',
+      label: 'API Key',
+      type: 'string',
+      required: true,
+      helpText: 'Your AI Primitives API key'
+    },
+    {
+      key: 'apiUrl',
+      label: 'API URL',
+      type: 'string',
+      required: true,
+      default: 'https://ai.do',
+      helpText: 'The URL of the AI Primitives API'
+    }
+  ],
+  
+  test: {
+    url: '{{bundle.authData.apiUrl}}/api/${collection.slug}',
+    method: 'GET',
+    headers: {
+      'Authorization': 'Bearer {{bundle.authData.apiKey}}',
+      'Content-Type': 'application/json'
+    },
+    params: {
+      limit: 1
+    },
+    body: {},
+    removeMissingValuesFrom: {},
+  },
+  
+  connectionLabel: '{{bundle.authData.apiUrl}}'
+};
+`
+}

--- a/integrations/zapier/src/templates/create.ts
+++ b/integrations/zapier/src/templates/create.ts
@@ -1,0 +1,143 @@
+import { ZapierCollectionConfig, ZapierField } from '../types/collection'
+import { pascalCase, titleCase, sentenceCase } from '../utils/stringUtils'
+
+/**
+ * Generates input fields for a Zapier app
+ * @param fields The fields to generate input fields for
+ * @param collectionSentence The collection name in sentence case
+ * @returns The input fields as a string
+ */
+function generateInputFields(fields: ZapierField[], collectionSentence: string): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      const required = 'required' in field && field.required === true
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: '${fieldType === 'number' ? 'number' : fieldType === 'checkbox' ? 'boolean' : 'string'}',
+      required: ${required},
+      helpText: 'The ${sentenceCase(fieldName)} of the ${collectionSentence}'
+    }`
+      } else if (fieldType === 'relationship' && field.relationTo) {
+        // Handle relationship fields
+        const relationTo = Array.isArray(field.relationTo) ? field.relationTo[0] : field.relationTo
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: 'string',
+      required: ${required},
+      helpText: 'The ID of the related ${relationTo}'
+    }`
+      } else if (fieldType === 'array' && field.fields) {
+        // Handle array fields (simplified - in real implementation would need dynamic fields)
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: 'string',
+      required: ${required},
+      helpText: 'JSON array of ${fieldName} items'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates output fields for a Zapier app
+ * @param fields The fields to generate output fields for
+ * @returns The output fields as a string
+ */
+function generateOutputFields(fields: ZapierField[]): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code', 'relationship', 'array'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates the creates.js file for a Zapier app
+ * @param collection The collection to generate the creates for
+ * @returns The content of the creates.js file
+ */
+export function generateCreateTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+  const collectionSentence = sentenceCase(collection.slug)
+
+  // Generate input fields based on collection fields
+  const inputFields = collection.fields
+    ? generateInputFields(collection.fields, collectionSentence)
+    : ''
+
+  // Generate output fields based on collection fields
+  const outputFields = collection.fields
+    ? generateOutputFields(collection.fields)
+    : ''
+
+  return `// Create ${collectionTitle} for Zapier
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: \`\${bundle.authData.apiUrl}/api/${collection.slug}\`,
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: bundle.inputData
+  });
+
+  return response.data;
+};
+
+module.exports = {
+  key: 'create${collectionName}',
+  noun: '${collectionTitle}',
+  
+  display: {
+    label: 'Create ${collectionTitle}',
+    description: 'Creates a new ${collectionSentence}.'
+  },
+  
+  operation: {
+    perform,
+    
+    inputFields: [
+${inputFields}
+    ],
+    
+    outputFields: [
+      {
+        key: 'id',
+        label: 'ID'
+      },
+${outputFields}
+    ],
+    
+    sample: {
+      id: 'sample-id-1234',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  }
+};
+`
+}

--- a/integrations/zapier/src/templates/delete.ts
+++ b/integrations/zapier/src/templates/delete.ts
@@ -1,0 +1,57 @@
+import { ZapierCollectionConfig } from '../types/collection'
+import { pascalCase, titleCase, sentenceCase } from '../utils/stringUtils'
+
+/**
+ * Generates the deletes.js file for a Zapier app
+ * @param collection The collection to generate the deletes for
+ * @returns The content of the deletes.js file
+ */
+export function generateDeleteTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+  const collectionSentence = sentenceCase(collection.slug)
+
+  return `// Delete ${collectionTitle} for Zapier
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: \`\${bundle.authData.apiUrl}/api/${collection.slug}/\${bundle.inputData.id}\`,
+    method: 'DELETE',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    }
+  });
+
+  return response.data;
+};
+
+module.exports = {
+  key: 'delete${collectionName}',
+  noun: '${collectionTitle}',
+  
+  display: {
+    label: 'Delete ${collectionTitle}',
+    description: 'Deletes a ${collectionSentence}.'
+  },
+  
+  operation: {
+    perform,
+    
+    inputFields: [
+      {
+        key: 'id',
+        label: 'ID',
+        type: 'string',
+        required: true,
+        helpText: 'The ID of the ${collectionSentence} to delete'
+      }
+    ],
+    
+    sample: {
+      id: 'sample-id-1234',
+      deleted: true
+    }
+  }
+};
+`
+}

--- a/integrations/zapier/src/templates/get.ts
+++ b/integrations/zapier/src/templates/get.ts
@@ -1,0 +1,95 @@
+import { ZapierCollectionConfig, ZapierField } from '../types/collection'
+import { pascalCase, titleCase, sentenceCase } from '../utils/stringUtils'
+
+/**
+ * Generates output fields for a Zapier app
+ * @param fields The fields to generate output fields for
+ * @returns The output fields as a string
+ */
+function generateOutputFields(fields: ZapierField[]): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code', 'relationship', 'array'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates the gets.js file for a Zapier app
+ * @param collection The collection to generate the gets for
+ * @returns The content of the gets.js file
+ */
+export function generateGetTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+  const collectionSentence = sentenceCase(collection.slug)
+
+  // Generate output fields based on collection fields
+  const outputFields = collection.fields
+    ? generateOutputFields(collection.fields)
+    : ''
+
+  return `// Get ${collectionTitle} for Zapier
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: \`\${bundle.authData.apiUrl}/api/${collection.slug}/\${bundle.inputData.id}\`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    }
+  });
+
+  return response.data;
+};
+
+module.exports = {
+  key: 'get${collectionName}',
+  noun: '${collectionTitle}',
+  
+  display: {
+    label: 'Get ${collectionTitle}',
+    description: 'Gets a ${collectionSentence} by ID.'
+  },
+  
+  operation: {
+    perform,
+    
+    inputFields: [
+      {
+        key: 'id',
+        label: 'ID',
+        type: 'string',
+        required: true,
+        helpText: 'The ID of the ${collectionSentence} to retrieve'
+      }
+    ],
+    
+    outputFields: [
+      {
+        key: 'id',
+        label: 'ID'
+      },
+${outputFields}
+    ],
+    
+    sample: {
+      id: 'sample-id-1234',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  }
+};
+`
+}

--- a/integrations/zapier/src/templates/list.ts
+++ b/integrations/zapier/src/templates/list.ts
@@ -1,0 +1,173 @@
+import { ZapierCollectionConfig, ZapierField } from '../types/collection'
+import { camelCase, pascalCase, titleCase, sentenceCase } from '../utils/stringUtils'
+
+/**
+ * Generates input fields for filtering in a Zapier app
+ * @param fields The fields to generate input fields for
+ * @returns The input fields as a string
+ */
+function generateInputFields(fields: ZapierField[]): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'textarea', 'code'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: '${fieldType === 'number' ? 'number' : 'string'}',
+      required: false,
+      helpText: 'Filter by ${sentenceCase(fieldName)}'
+    }`
+      } else if (fieldType === 'relationship' && field.relationTo) {
+        // Handle relationship fields
+        const relationTo = Array.isArray(field.relationTo) ? field.relationTo[0] : field.relationTo
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: 'string',
+      required: false,
+      helpText: 'Filter by the ID of the related ${relationTo}'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates output fields for a Zapier app
+ * @param fields The fields to generate output fields for
+ * @returns The output fields as a string
+ */
+function generateOutputFields(fields: ZapierField[]): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code', 'relationship', 'array'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates the searches.js file for a Zapier app
+ * @param collection The collection to generate the searches for
+ * @returns The content of the searches.js file
+ */
+export function generateListTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+  const collectionCamel = camelCase(collection.slug)
+  const collectionSentence = sentenceCase(collection.slug)
+
+  // Generate input fields based on collection fields
+  const inputFields = collection.fields
+    ? generateInputFields(collection.fields)
+    : ''
+
+  // Generate output fields based on collection fields
+  const outputFields = collection.fields
+    ? generateOutputFields(collection.fields)
+    : ''
+
+  return `// List ${collectionTitle} search for Zapier
+const perform = async (z, bundle) => {
+  const response = await z.request({
+    url: \`\${bundle.authData.apiUrl}/api/${collection.slug}\`,
+    method: 'GET',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    params: {
+      limit: bundle.inputData.limit || 10,
+      page: bundle.inputData.page || 1,
+      where: JSON.stringify(buildWhereClause(bundle.inputData))
+    }
+  });
+
+  return response.data.docs || [];
+};
+
+// Build the where clause for filtering
+const buildWhereClause = (inputData) => {
+  const where = {};
+  
+  // Add filters for each field if provided
+  ${collection.fields
+    ? collection.fields
+        .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+        .map(field => {
+          const fieldName = field.name as string
+          return `  if (inputData.${fieldName}) {
+    where.${fieldName} = { equals: inputData.${fieldName} };
+  }`
+        })
+        .join('\n  ')
+    : '  // No fields to filter by'}
+  
+  return where;
+};
+
+module.exports = {
+  key: 'find${collectionName}',
+  noun: '${collectionTitle}',
+  
+  display: {
+    label: 'Find ${collectionTitle}',
+    description: 'Finds ${collectionSentence} in your account.'
+  },
+  
+  operation: {
+    perform,
+    
+    inputFields: [
+      {
+        key: 'limit',
+        label: 'Limit',
+        type: 'integer',
+        required: false,
+        default: 10,
+        helpText: 'Maximum number of records to return'
+      },
+      {
+        key: 'page',
+        label: 'Page',
+        type: 'integer',
+        required: false,
+        default: 1,
+        helpText: 'Page number for pagination'
+      },
+${inputFields}
+    ],
+    
+    outputFields: [
+      {
+        key: 'id',
+        label: 'ID'
+      },
+${outputFields}
+    ],
+    
+    sample: {
+      id: 'sample-id-1234',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  }
+};
+`
+}

--- a/integrations/zapier/src/templates/update.ts
+++ b/integrations/zapier/src/templates/update.ts
@@ -1,0 +1,153 @@
+import { ZapierCollectionConfig, ZapierField } from '../types/collection'
+import { pascalCase, titleCase, sentenceCase } from '../utils/stringUtils'
+
+/**
+ * Generates input fields for a Zapier app
+ * @param fields The fields to generate input fields for
+ * @param collectionSentence The collection name in sentence case
+ * @returns The input fields as a string
+ */
+function generateInputFields(fields: ZapierField[], collectionSentence: string): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: '${fieldType === 'number' ? 'number' : fieldType === 'checkbox' ? 'boolean' : 'string'}',
+      required: false,
+      helpText: 'The ${sentenceCase(fieldName)} of the ${collectionSentence}'
+    }`
+      } else if (fieldType === 'relationship' && field.relationTo) {
+        // Handle relationship fields
+        const relationTo = Array.isArray(field.relationTo) ? field.relationTo[0] : field.relationTo
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: 'string',
+      required: false,
+      helpText: 'The ID of the related ${relationTo}'
+    }`
+      } else if (fieldType === 'array' && field.fields) {
+        // Handle array fields (simplified - in real implementation would need dynamic fields)
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}',
+      type: 'string',
+      required: false,
+      helpText: 'JSON array of ${fieldName} items'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates output fields for a Zapier app
+ * @param fields The fields to generate output fields for
+ * @returns The output fields as a string
+ */
+function generateOutputFields(fields: ZapierField[]): string {
+  return fields
+    .filter(field => typeof field === 'object' && 'name' in field && field.name && field.type)
+    .map(field => {
+      const fieldName = field.name as string
+      const fieldType = field.type as string
+      
+      if (['text', 'email', 'number', 'date', 'checkbox', 'textarea', 'code', 'relationship', 'array'].includes(fieldType)) {
+        return `    {
+      key: '${fieldName}',
+      label: '${titleCase(fieldName)}'
+    }`
+      }
+      return null
+    })
+    .filter(Boolean)
+    .join(',\n')
+}
+
+/**
+ * Generates the updates.js file for a Zapier app
+ * @param collection The collection to generate the updates for
+ * @returns The content of the updates.js file
+ */
+export function generateUpdateTemplate(collection: ZapierCollectionConfig): string {
+  const collectionName = pascalCase(collection.slug)
+  const collectionTitle = titleCase(collection.slug)
+  const collectionSentence = sentenceCase(collection.slug)
+
+  // Generate input fields based on collection fields
+  const inputFields = collection.fields
+    ? generateInputFields(collection.fields, collectionSentence)
+    : ''
+
+  // Generate output fields based on collection fields
+  const outputFields = collection.fields
+    ? generateOutputFields(collection.fields)
+    : ''
+
+  return `// Update ${collectionTitle} for Zapier
+const perform = async (z, bundle) => {
+  // Remove id from the input data as it's in the URL
+  const inputData = { ...bundle.inputData };
+  delete inputData.id;
+  
+  const response = await z.request({
+    url: \`\${bundle.authData.apiUrl}/api/${collection.slug}/\${bundle.inputData.id}\`,
+    method: 'PATCH',
+    headers: {
+      'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    },
+    body: inputData
+  });
+
+  return response.data;
+};
+
+module.exports = {
+  key: 'update${collectionName}',
+  noun: '${collectionTitle}',
+  
+  display: {
+    label: 'Update ${collectionTitle}',
+    description: 'Updates an existing ${collectionSentence}.'
+  },
+  
+  operation: {
+    perform,
+    
+    inputFields: [
+      {
+        key: 'id',
+        label: 'ID',
+        type: 'string',
+        required: true,
+        helpText: 'The ID of the ${collectionSentence} to update'
+      },
+${inputFields}
+    ],
+    
+    outputFields: [
+      {
+        key: 'id',
+        label: 'ID'
+      },
+${outputFields}
+    ],
+    
+    sample: {
+      id: 'sample-id-1234',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    }
+  }
+};
+`
+}

--- a/integrations/zapier/src/types/collection.ts
+++ b/integrations/zapier/src/types/collection.ts
@@ -1,0 +1,52 @@
+/**
+ * Simplified interface for collection configuration used in Zapier templates
+ * This decouples the template code from specific Payload implementation details
+ */
+export interface ZapierCollectionConfig {
+  /**
+   * The slug of the collection
+   */
+  slug: string;
+  
+  /**
+   * The fields of the collection
+   */
+  fields?: ZapierField[];
+  
+  /**
+   * Admin configuration
+   */
+  admin?: {
+    useAsTitle?: string;
+  };
+}
+
+/**
+ * Simplified interface for field configuration used in Zapier templates
+ */
+export interface ZapierField {
+  /**
+   * The name of the field
+   */
+  name?: string;
+  
+  /**
+   * The type of the field
+   */
+  type?: string;
+  
+  /**
+   * Whether the field is required
+   */
+  required?: boolean;
+  
+  /**
+   * For relationship fields, the collection to relate to
+   */
+  relationTo?: string | string[];
+  
+  /**
+   * For array fields, the fields within the array
+   */
+  fields?: ZapierField[];
+}

--- a/integrations/zapier/src/utils/stringUtils.ts
+++ b/integrations/zapier/src/utils/stringUtils.ts
@@ -1,0 +1,57 @@
+/**
+ * Converts a string to camelCase
+ * @param str The string to convert
+ * @returns The camelCase string
+ */
+export function camelCase(str: string): string {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+    .replace(/^([A-Z])/, (m) => m.toLowerCase());
+}
+
+/**
+ * Converts a string to PascalCase
+ * @param str The string to convert
+ * @returns The PascalCase string
+ */
+export function pascalCase(str: string): string {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? c.toUpperCase() : ''))
+    .replace(/^(.)/, (m) => m.toUpperCase());
+}
+
+/**
+ * Converts a string to kebab-case
+ * @param str The string to convert
+ * @returns The kebab-case string
+ */
+export function kebabCase(str: string): string {
+  return str
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+/**
+ * Converts a string to Title Case
+ * @param str The string to convert
+ * @returns The Title Case string
+ */
+export function titleCase(str: string): string {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? ' ' + c.toUpperCase() : ' '))
+    .trim()
+    .replace(/^(.)/, (m) => m.toUpperCase());
+}
+
+/**
+ * Converts a string to Sentence case
+ * @param str The string to convert
+ * @returns The Sentence case string
+ */
+export function sentenceCase(str: string): string {
+  return str
+    .replace(/[-_\s]+(.)?/g, (_, c) => (c ? ' ' + c.toLowerCase() : ' '))
+    .trim()
+    .replace(/^(.)/, (m) => m.toUpperCase());
+}

--- a/integrations/zapier/test/mocks/payload.ts
+++ b/integrations/zapier/test/mocks/payload.ts
@@ -1,0 +1,19 @@
+// Mock for payload CollectionConfig type
+export interface CollectionConfig {
+  slug: string;
+  fields: Array<{
+    name: string;
+    type: string;
+    required?: boolean;
+    relationTo?: string | string[];
+    fields?: Array<{
+      name: string;
+      type: string;
+      required?: boolean;
+      relationTo?: string | string[];
+    }>;
+  }>;
+  admin?: {
+    useAsTitle?: string;
+  };
+}


### PR DESCRIPTION
Fixes #140

This PR addresses the issue with Zapier app generation by:

1. Adding missing template files for app generation
2. Ensuring proper handling of relationship fields in CRUD operations
3. Adding support for array fields with JSON input

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/538eb8f00df141989bdd7feba2bc3bfb)