### PR TITLE
Fix TypeScript errors in test files

### DIFF
--- a/tests/api/root.test.ts
+++ b/tests/api/root.test.ts
@@ -48,9 +48,11 @@ describe('Root API endpoint', () => {
       
       const data = await response.json()
       expect(data).toBeDefined()
-    } catch (error) {
-      if (error instanceof Error || (error && typeof error.message === 'string')) {
+    } catch (error: unknown) {
+      if (error instanceof Error) {
         console.log('API test failed with error:', error.message)
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
+        console.log('API test failed with error:', (error as { message: string }).message)
       } else {
         console.log('API test failed with an unknown error')
       }

--- a/tests/e2e/admin.test.ts
+++ b/tests/e2e/admin.test.ts
@@ -15,9 +15,11 @@ describe('Admin page', () => {
       browser = await chromium.launch({
         headless: true
       })
-    } catch (error) {
-      if (error instanceof Error || (error && typeof error.message === 'string')) {
+    } catch (error: unknown) {
+      if (error instanceof Error) {
         console.error('Failed to launch browser:', error.message)
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
+        console.error('Failed to launch browser:', (error as { message: string }).message)
       } else {
         console.error('Failed to launch browser with an unknown error')
       }

--- a/tests/e2e/docs.test.ts
+++ b/tests/e2e/docs.test.ts
@@ -15,9 +15,11 @@ describe('Documentation page', () => {
       browser = await chromium.launch({
         headless: true
       })
-    } catch (error) {
-      if (error instanceof Error || (error && typeof error.message === 'string')) {
+    } catch (error: unknown) {
+      if (error instanceof Error) {
         console.error('Failed to launch browser:', error.message)
+      } else if (error && typeof error === 'object' && 'message' in error && typeof (error as { message: unknown }).message === 'string') {
+        console.error('Failed to launch browser:', (error as { message: string }).message)
       } else {
         console.error('Failed to launch browser with an unknown error')
       }


### PR DESCRIPTION
This PR fixes TypeScript errors in the test files by properly typing error objects.

Changes made:
1. Added proper type annotations for error objects in catch blocks
2. Used type guards to safely access the message property
3. Fixed the error handling in tests/api/root.test.ts, tests/e2e/admin.test.ts, and tests/e2e/docs.test.ts

All TypeScript errors are now resolved and the tests pass successfully.

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c6e9e0190f05415687aafbe633097696)