### PR TITLE
Add /api/actions endpoint to fetch actions from Composio API

### DIFF
--- a/app/(apis)/api/actions/route.ts
+++ b/app/(apis)/api/actions/route.ts
@@ -1,0 +1,19 @@
+import { API } from 'clickable-apis'
+
+export const GET = API(async (request, { db, user, url }) => {
+  // Check if API key is configured
+  const apiKey = process.env.COMPOSIO_API_KEY
+  if (!apiKey) {
+    return new Response('Composio API key not configured', { status: 500 })
+  }
+
+  // Pull the available actions from Composio
+  const response = await fetch('https://backend.composio.dev/api/v2/actions/list/all', {
+    headers: {
+      'x-api-key': apiKey,
+    },
+  })
+
+  const data = await response.json()
+  return { actions: data.actions || data }
+})

--- a/tests/api/actions/route.test.ts
+++ b/tests/api/actions/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API module
+vi.mock('clickable-apis', () => ({
+  API: (handler) => handler,
+}))
+
+// Mock the fetch function
+global.fetch = vi.fn()
+
+// Mock environment variables
+vi.stubEnv('COMPOSIO_API_KEY', 'test-api-key')
+
+// Import after mocks are set up
+import { GET } from '../../../app/(apis)/api/actions/route'
+
+describe('Actions API', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('should fetch actions with the correct API key header', async () => {
+      // Mock the fetch response
+      const mockResponse = {
+        json: vi.fn().mockResolvedValue({ actions: [] }),
+      }
+      global.fetch.mockResolvedValue(mockResponse)
+
+      // Call the GET handler
+      await GET({} as Request, { url: 'https://example.com/api/actions' } as any)
+
+      // Verify fetch was called with the correct URL and headers
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://backend.composio.dev/api/v2/actions/list/all',
+        {
+          headers: {
+            'x-api-key': 'test-api-key',
+          },
+        }
+      )
+    })
+
+    it('should return a 500 response if API key is not configured', async () => {
+      // Temporarily remove the API key
+      const originalApiKey = process.env.COMPOSIO_API_KEY
+      delete process.env.COMPOSIO_API_KEY
+
+      // Call the GET handler
+      const response = await GET({} as Request, { url: 'https://example.com/api/actions' } as any)
+
+      // Verify response
+      expect(response).toBeInstanceOf(Response)
+      expect(response.status).toBe(500)
+
+      // Restore the API key
+      process.env.COMPOSIO_API_KEY = originalApiKey
+    })
+  })
+})


### PR DESCRIPTION
This PR adds a new API endpoint at `/api/actions` that follows the pattern from the integrations endpoint but fetches data from the Composio actions API.

Changes:
- Created new endpoint at `/api/actions` that fetches data from `https://backend.composio.dev/api/v2/actions/list/all`
- Added tests to verify the endpoint works correctly

Fixes #174

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7fa9899504d1452bb27c8759bcf27d04)