### PR TITLE
Add triggers API endpoint

### DIFF
--- a/app/(apis)/api/triggers/route.ts
+++ b/app/(apis)/api/triggers/route.ts
@@ -1,0 +1,19 @@
+import { API } from 'clickable-apis'
+
+export const GET = API(async (request, { db, user, url }) => {
+  // Check if API key is configured
+  const apiKey = process.env.COMPOSIO_API_KEY
+  if (!apiKey) {
+    return new Response('Composio API key not configured', { status: 500 })
+  }
+
+  // Pull the available triggers from Composio
+  const response = await fetch('https://backend.composio.dev/api/v1/triggers', {
+    headers: {
+      'x-api-key': apiKey,
+    },
+  })
+
+  const data = await response.json()
+  return { triggers: data.triggers || data }
+})

--- a/tests/api/triggers/route.test.ts
+++ b/tests/api/triggers/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the API module
+vi.mock('clickable-apis', () => ({
+  API: (handler) => handler,
+}))
+
+// Mock the fetch function
+global.fetch = vi.fn()
+
+// Mock environment variables
+vi.stubEnv('COMPOSIO_API_KEY', 'test-api-key')
+
+// Import after mocks are set up
+import { GET } from '../../../app/(apis)/api/triggers/route'
+
+describe('Triggers API', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+  })
+
+  describe('GET', () => {
+    it('should fetch triggers with the correct API key header', async () => {
+      // Mock the fetch response
+      const mockResponse = {
+        json: vi.fn().mockResolvedValue({ triggers: [] }),
+      }
+      global.fetch.mockResolvedValue(mockResponse)
+
+      // Call the GET handler
+      await GET({} as Request, { url: 'https://example.com/api/triggers' } as any)
+
+      // Verify fetch was called with the correct URL and headers
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://backend.composio.dev/api/v1/triggers',
+        {
+          headers: {
+            'x-api-key': 'test-api-key',
+          },
+        }
+      )
+    })
+
+    it('should return a 500 response if API key is not configured', async () => {
+      // Temporarily remove the API key
+      const originalApiKey = process.env.COMPOSIO_API_KEY
+      delete process.env.COMPOSIO_API_KEY
+
+      // Call the GET handler
+      const response = await GET({} as Request, { url: 'https://example.com/api/triggers' } as any)
+
+      // Verify response
+      expect(response).toBeInstanceOf(Response)
+      expect(response.status).toBe(500)
+
+      // Restore the API key
+      process.env.COMPOSIO_API_KEY = originalApiKey
+    })
+  })
+})


### PR DESCRIPTION
Fixes #173

This PR adds a new API endpoint for triggers following the pattern from the integrations endpoint. The endpoint connects to https://backend.composio.dev/api/v1/triggers and returns the data in a similar format to the integrations endpoint.

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fa9c86b20deb4c32b923b6534b965352)