### PR TITLE
Fix URL encoding in apis.do SDK search parameters

### DIFF
--- a/sdks/apis.do/src/client.ts
+++ b/sdks/apis.do/src/client.ts
@@ -1,0 +1,119 @@
+import { ErrorResponse, ListResponse, QueryParams } from './types';
+
+export interface ClientOptions {
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+
+export class ApiClient {
+  private baseUrl: string;
+  private headers: Record<string, string>;
+
+  constructor(options: ClientOptions = {}) {
+    this.baseUrl = options.baseUrl || 'https://apis.do';
+    this.headers = {
+      'Content-Type': 'application/json',
+      ...options.headers,
+    };
+
+    if (options.apiKey) {
+      this.headers['Authorization'] = `Bearer ${options.apiKey}`;
+    }
+  }
+
+  private async request<T>(
+    method: string,
+    path: string,
+    data?: any,
+    params?: QueryParams
+  ): Promise<T> {
+    const url = new URL(path, this.baseUrl);
+    
+    // Add query parameters
+    if (params) {
+      Object.entries(params).forEach(([key, value]) => {
+        if (value !== undefined) {
+          if (key === 'where' && typeof value === 'object') {
+            url.searchParams.append(key, JSON.stringify(value));
+          } else {
+            // Let URLSearchParams handle the encoding naturally
+            url.searchParams.append(key, String(value));
+          }
+        }
+      });
+    }
+
+    const options: RequestInit = {
+      method,
+      headers: this.headers,
+    };
+
+    if (data) {
+      options.body = JSON.stringify(data);
+    }
+
+    const response = await fetch(url.toString(), options);
+    const responseData = await response.json();
+
+    if (!response.ok) {
+      throw new Error(
+        (responseData as ErrorResponse).errors?.[0]?.message || 
+        `API request failed with status ${response.status}`
+      );
+    }
+
+    return responseData as T;
+  }
+
+  async get<T>(path: string, params?: QueryParams): Promise<T> {
+    return this.request<T>('GET', path, undefined, params);
+  }
+
+  async post<T>(path: string, data: any): Promise<T> {
+    return this.request<T>('POST', path, data);
+  }
+
+  async put<T>(path: string, data: any): Promise<T> {
+    return this.request<T>('PUT', path, data);
+  }
+
+  async patch<T>(path: string, data: any): Promise<T> {
+    return this.request<T>('PATCH', path, data);
+  }
+
+  async delete<T>(path: string): Promise<T> {
+    return this.request<T>('DELETE', path);
+  }
+
+  async list<T>(collection: string, params?: QueryParams): Promise<ListResponse<T>> {
+    return this.get<ListResponse<T>>(`/api/${collection}`, params);
+  }
+
+  async getById<T>(collection: string, id: string): Promise<T> {
+    return this.get<T>(`/api/${collection}/${id}`);
+  }
+
+  async create<T>(collection: string, data: Partial<T>): Promise<T> {
+    return this.post<T>(`/api/${collection}`, data);
+  }
+
+  async update<T>(collection: string, id: string, data: Partial<T>): Promise<T> {
+    return this.patch<T>(`/api/${collection}/${id}`, data);
+  }
+
+  async replace<T>(collection: string, id: string, data: T): Promise<T> {
+    return this.put<T>(`/api/${collection}/${id}`, data);
+  }
+
+  async remove<T>(collection: string, id: string): Promise<T> {
+    return this.delete<T>(`/api/${collection}/${id}`);
+  }
+
+  async search<T>(collection: string, query: string, params?: QueryParams): Promise<ListResponse<T>> {
+    return this.get<ListResponse<T>>(`/api/${collection}/search`, {
+      ...params,
+      q: query,
+    });
+  }
+}

--- a/sdks/apis.do/src/types.ts
+++ b/sdks/apis.do/src/types.ts
@@ -1,0 +1,25 @@
+export interface ErrorResponse {
+  errors?: Array<{
+    message: string;
+    code?: string;
+    path?: string;
+  }>;
+}
+
+export interface ListResponse<T> {
+  data: T[];
+  meta?: {
+    total?: number;
+    page?: number;
+    pageSize?: number;
+    hasNextPage?: boolean;
+  };
+}
+
+export interface QueryParams {
+  [key: string]: any;
+  limit?: number;
+  page?: number;
+  sort?: string | string[];
+  where?: Record<string, any>;
+}


### PR DESCRIPTION
This PR fixes issue #181 by removing the manual `encodeURIComponent()` call in the `apis.do` SDK client. The previous implementation was causing double encoding of URL parameters, which resulted in search queries not working correctly.

The fix allows the native `URLSearchParams` to handle the encoding naturally, which is the correct approach for URL parameter encoding.

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5aec53e436b14ad7859bb29f43865bf9)