### PR TITLE
Add next/prev seed links to functions.do API response

### DIFF
--- a/app/(apis)/functions/[functionName]/route.ts
+++ b/app/(apis)/functions/[functionName]/route.ts
@@ -23,7 +23,27 @@ export const GET = API(async (request, { db, user, url, payload, params, req }) 
   const keys = Object.keys(output || {})
   const type = keys.length === 1 ? keys[0] : undefined
   const data = type ? output[type] : output
-  return { functionName, args, type, data, reasoning: results?.reasoning?.split('\n'), settings, latency }
+  
+  // Create links object with next and prev seed values
+  const currentSeed = parseInt(seed)
+  const baseUrl = request.nextUrl.origin + request.nextUrl.pathname
+  
+  // Create a copy of the current search params
+  const nextParams = new URLSearchParams(request.nextUrl.searchParams)
+  nextParams.set('seed', (currentSeed + 1).toString())
+  
+  const links: { next: string; prev?: string } = {
+    next: `${baseUrl}?${nextParams.toString()}`,
+  }
+  
+  // Only include prev link if seed is greater than 1
+  if (currentSeed > 1) {
+    const prevParams = new URLSearchParams(request.nextUrl.searchParams)
+    prevParams.set('seed', (currentSeed - 1).toString())
+    links.prev = `${baseUrl}?${prevParams.toString()}`
+  }
+  
+  return { functionName, args, links, type, data, reasoning: results?.reasoning?.split('\n'), settings, latency }
 
   // const job = await payload.jobs.queue({
   //   task: 'executeFunction',

--- a/tests/api/functions/links.test.ts
+++ b/tests/api/functions/links.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest'
+import { GET } from '@/app/(apis)/functions/[functionName]/route'
+import { createMocks } from 'node-mocks-http'
+
+// Mock the executeFunction dependency
+vi.mock('@/tasks/executeFunction', () => ({
+  executeFunction: vi.fn().mockResolvedValue({
+    output: { result: 'test result' },
+    reasoning: 'test reasoning',
+  }),
+}))
+
+describe('Functions API with seed links', () => {
+  it('should include next link and no prev link when seed is 1', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: '/functions/testFunction?seed=1',
+    })
+
+    // Mock the request object with the necessary properties
+    const request = {
+      nextUrl: {
+        origin: 'https://functions.do',
+        pathname: '/testFunction',
+        searchParams: new URLSearchParams('seed=1'),
+      },
+    }
+
+    const context = {
+      params: { functionName: 'testFunction' },
+      payload: {},
+    }
+
+    const response = await GET(request as any, context as any)
+    const data = await response.json()
+
+    expect(data.links).toBeDefined()
+    expect(data.links.next).toBeDefined()
+    expect(data.links.next).toContain('seed=2')
+    expect(data.links.prev).toBeUndefined()
+  })
+
+  it('should include both next and prev links when seed is greater than 1', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: '/functions/testFunction?seed=5',
+    })
+
+    // Mock the request object with the necessary properties
+    const request = {
+      nextUrl: {
+        origin: 'https://functions.do',
+        pathname: '/testFunction',
+        searchParams: new URLSearchParams('seed=5'),
+      },
+    }
+
+    const context = {
+      params: { functionName: 'testFunction' },
+      payload: {},
+    }
+
+    const response = await GET(request as any, context as any)
+    const data = await response.json()
+
+    expect(data.links).toBeDefined()
+    expect(data.links.next).toBeDefined()
+    expect(data.links.next).toContain('seed=6')
+    expect(data.links.prev).toBeDefined()
+    expect(data.links.prev).toContain('seed=4')
+  })
+
+  it('should preserve other query parameters in links', async () => {
+    const { req, res } = createMocks({
+      method: 'GET',
+      url: '/functions/testFunction?seed=3&temperature=0.7&model=gpt-4',
+    })
+
+    // Mock the request object with the necessary properties
+    const request = {
+      nextUrl: {
+        origin: 'https://functions.do',
+        pathname: '/testFunction',
+        searchParams: new URLSearchParams('seed=3&temperature=0.7&model=gpt-4'),
+      },
+    }
+
+    const context = {
+      params: { functionName: 'testFunction' },
+      payload: {},
+    }
+
+    const response = await GET(request as any, context as any)
+    const data = await response.json()
+
+    expect(data.links.next).toContain('seed=4')
+    expect(data.links.next).toContain('temperature=0.7')
+    expect(data.links.next).toContain('model=gpt-4')
+    
+    expect(data.links.prev).toContain('seed=2')
+    expect(data.links.prev).toContain('temperature=0.7')
+    expect(data.links.prev).toContain('model=gpt-4')
+  })
+})


### PR DESCRIPTION
This PR adds next and prev seed links to the functions.do API response as requested in issue #137.

## Changes

- Added a `links` object before the `data` object in the API response
- The `links` object contains `next` and `prev` URLs with appropriate seed values
- The `prev` link is only included when the current seed is greater than 1
- All other query parameters are preserved in the links
- Added tests to verify the functionality

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c1bd94d2901e41b5b7b4b2d5de5004b8)