### PR TITLE
docs: add Base64 encoding requirement comment for COMPOSIO_WEBHOOK_SE…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,4 +18,4 @@ AI_GATEWAY_URL=""
 AI_GATEWAY_TOKEN=""
 
 COMPOSIO_API_KEY=""
-COMPOSIO_WEBHOOK_SECRET=""
+COMPOSIO_WEBHOOK_SECRET="" # Must be Base64 encoded, can optionally start with whsec_


### PR DESCRIPTION
…CRET