### PR TITLE
Fix /api path routing to domain API root

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -36,6 +36,13 @@ export function middleware(request: NextRequest) {
   // TODO: we need to ensure that all of the apis are at the root by default
   // I think this is preferred as it is what we want for localhost and API gateways like apis.do
   console.log({ apiName, apis, name: apis[apiName] })
+  
+  // Special handler for /api path to route to the domain (minus .do) API path
+  if (pathname === '/api' && apis[apiName]) {
+    console.log('Rewriting /api to API root', { apiName, hostname, pathname, search })
+    return NextResponse.rewrite(new URL(`/${apiName}${search}`, request.url))
+  }
+  
   if (apis[apiName]) {
     console.log('Rewriting to API', { apiName, hostname, pathname, search })
     return NextResponse.rewrite(new URL(`/${apiName}${pathname}${search}`, request.url))

--- a/tests/middleware.test.ts
+++ b/tests/middleware.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { middleware } from '../middleware'
+import { NextRequest, NextResponse } from 'next/server'
+
+// Mock NextResponse
+vi.mock('next/server', async () => {
+  const actual = await vi.importActual('next/server')
+  return {
+    ...actual,
+    NextResponse: {
+      rewrite: vi.fn().mockImplementation((url) => ({ url, rewrite: true })),
+    },
+  }
+})
+
+describe('middleware', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should rewrite /api to the API root for valid API domains', () => {
+    // Create a mock request for functions.do/api
+    const request = {
+      nextUrl: {
+        hostname: 'functions.do',
+        pathname: '/api',
+        search: '?param=value',
+      },
+      url: 'https://functions.do/api?param=value',
+    } as unknown as NextRequest
+
+    const result = middleware(request)
+    
+    // Verify that NextResponse.rewrite was called with the correct URL
+    expect(NextResponse.rewrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/functions',
+        search: '?param=value',
+      })
+    )
+    expect(result).toEqual({
+      url: expect.objectContaining({
+        pathname: '/functions',
+        search: '?param=value',
+      }),
+      rewrite: true,
+    })
+  })
+
+  it('should handle normal API paths correctly', () => {
+    // Create a mock request for functions.do/some/path
+    const request = {
+      nextUrl: {
+        hostname: 'functions.do',
+        pathname: '/some/path',
+        search: '?param=value',
+      },
+      url: 'https://functions.do/some/path?param=value',
+    } as unknown as NextRequest
+
+    const result = middleware(request)
+    
+    // Verify that NextResponse.rewrite was called with the correct URL
+    expect(NextResponse.rewrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/functions/some/path',
+        search: '?param=value',
+      })
+    )
+    expect(result).toEqual({
+      url: expect.objectContaining({
+        pathname: '/functions/some/path',
+        search: '?param=value',
+      }),
+      rewrite: true,
+    })
+  })
+
+  it('should handle site domains correctly', () => {
+    // Create a mock request for functions.do/
+    const request = {
+      nextUrl: {
+        hostname: 'functions.do',
+        pathname: '/',
+        search: '',
+      },
+      url: 'https://functions.do/',
+    } as unknown as NextRequest
+
+    const result = middleware(request)
+    
+    // Verify that NextResponse.rewrite was called with the correct URL
+    expect(NextResponse.rewrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pathname: '/sites/functions.do/',
+      })
+    )
+    expect(result).toEqual({
+      url: expect.objectContaining({
+        pathname: '/sites/functions.do/',
+      }),
+      rewrite: true,
+    })
+  })
+})


### PR DESCRIPTION
This PR fixes issue #222 by ensuring that when users visit /api on a domain like functions.do, they get redirected to the API root path (/functions).

The middleware now checks if the pathname is exactly "/api" and if the hostname (without .do) is a valid API, and rewrites the URL accordingly.

Added tests to verify the behavior for:
- /api path on valid API domains
- Normal API paths
- Site domains

Closes #222

@nathanclevenger can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f67656ad2e1b4c81892cdf668c2ee9c4)