### PR TITLE
feat(auth): remove vercel url from auth client and options

### DIFF
--- a/lib/auth/auth-client.ts
+++ b/lib/auth/auth-client.ts
@@ -2,10 +2,7 @@ import { adminClient, apiKeyClient, inferAdditionalFields, multiSessionClient, o
 import { createAuthClient } from 'better-auth/react'
 import { toast } from 'sonner'
 
-const vercelURL = process.env.NEXT_PUBLIC_VERCEL_URL
-
 export const authClient = createAuthClient({
-  baseURL: vercelURL ? `https://${vercelURL}` : `${process.env.NEXT_PUBLIC_BETTER_AUTH_URL}`,
   plugins: [
     adminClient(),
     apiKeyClient(),

--- a/lib/auth/options.ts
+++ b/lib/auth/options.ts
@@ -9,12 +9,9 @@ export const betterAuthPlugins = [admin(), apiKey(), multiSession(), openAPI(), 
 
 export type BetterAuthPlugins = typeof betterAuthPlugins
 
-const vercelURL = process.env.VERCEL_URL
-
 export const betterAuthOptions: BetterAuthOptions = {
   secret: process.env.BETTER_AUTH_SECRET as string,
   appName: 'AGI Platform',
-  baseURL: vercelURL ? `https://${vercelURL}` : process.env.BETTER_AUTH_URL || 'http://localhost:3000',
   socialProviders: {
     google: {
       clientId: process.env.GOOGLE_CLIENT_ID as string,


### PR DESCRIPTION
remove vercel url from better-auth options, createAuthClient doesn't need a url and the options was getting the wrong url
