### PR TITLE
Add dynamic headers for AI requests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,8 @@ LINEAR_CLIENT_SECRET=""
 
 AI_GATEWAY_URL=""
 AI_GATEWAY_TOKEN=""
+AI_REFERER=""
+AI_TITLE=""
 
 COMPOSIO_API_KEY=""
 COMPOSIO_WEBHOOK_SECRET="" # Must be Base64 encoded, can optionally start with whsec_

--- a/tasks/ai/generateObject.ts
+++ b/tasks/ai/generateObject.ts
@@ -6,7 +6,11 @@ type GenerateObjectInput = {
   args: any
   schema?: Record<string, any>
   zodSchema?: any
-  settings?: any
+  settings?: {
+    referer?: string
+    title?: string
+    [key: string]: any
+  }
 }
 
 type GenerateObjectOutput = {
@@ -59,13 +63,15 @@ export const generateObject = async ({ input, req }: { input: GenerateObjectInpu
   }
 
   const url = process.env.AI_GATEWAY_URL ? process.env.AI_GATEWAY_URL + '/v1/chat/completions' : 'https://openrouter.ai/api/v1/chat/completions'
+  const referer = settings?.referer || process.env.AI_REFERER
+  const title = settings?.title || process.env.AI_TITLE
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${process.env.AI_GATEWAY_TOKEN || process.env.OPEN_ROUTER_API_KEY}`,
-      'HTTP-Referer': 'https://functions.do', // TODO: Figure out the proper logic to set/override the app
-      'X-Title': 'Functions.do - Reliable Structured Outputs Without Complexity', // TODO: Figure out a dynamic place for the app title
+      ...(referer ? { 'HTTP-Referer': referer } : {}),
+      ...(title ? { 'X-Title': title } : {}),
     },
     body: JSON.stringify(request),
   })

--- a/tasks/ai/generateObjectArray.ts
+++ b/tasks/ai/generateObjectArray.ts
@@ -5,7 +5,11 @@ type GenerateObjectArrayInput = {
   args: any
   schema?: Record<string, any>
   zodSchema?: any
-  settings?: any
+  settings?: {
+    referer?: string
+    title?: string
+    [key: string]: any
+  }
 }
 
 type GenerateObjectArrayOutput = {
@@ -54,13 +58,15 @@ export const generateObjectArray = async ({ input, req }: { input: GenerateObjec
   }
 
   const url = process.env.AI_GATEWAY_URL ? process.env.AI_GATEWAY_URL + '/v1/chat/completions' : 'https://openrouter.ai/api/v1/chat/completions'
+  const referer = settings?.referer || process.env.AI_REFERER
+  const title = settings?.title || process.env.AI_TITLE
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${process.env.AI_GATEWAY_TOKEN || process.env.OPEN_ROUTER_API_KEY}`,
-      'HTTP-Referer': 'https://functions.do', // TODO: Figure out the proper logic to set/override the app
-      'X-Title': 'Functions.do - Reliable Structured Outputs Without Complexity', // TODO: Figure out a dynamic place for the app title
+      ...(referer ? { 'HTTP-Referer': referer } : {}),
+      ...(title ? { 'X-Title': title } : {}),
     },
     body: JSON.stringify(request),
   })

--- a/tasks/ai/generateText.ts
+++ b/tasks/ai/generateText.ts
@@ -2,7 +2,11 @@
 type GenerateTextInput = {
   functionName: string
   args: any
-  settings?: any
+  settings?: {
+    referer?: string
+    title?: string
+    [key: string]: any
+  }
 }
 
 type GenerateTextOutput = {
@@ -33,13 +37,15 @@ export const generateText = async ({ input, req }: { input: GenerateTextInput; r
   }
 
   const url = process.env.AI_GATEWAY_URL ? process.env.AI_GATEWAY_URL + '/v1/chat/completions' : 'https://openrouter.ai/api/v1/chat/completions'
+  const referer = settings?.referer || process.env.AI_REFERER
+  const title = settings?.title || process.env.AI_TITLE
   const response = await fetch(url, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
       Authorization: `Bearer ${process.env.AI_GATEWAY_TOKEN || process.env.OPEN_ROUTER_API_KEY}`,
-      'HTTP-Referer': 'https://functions.do', // TODO: Figure out the proper logic to set/override the app
-      'X-Title': 'Functions.do - Reliable Structured Outputs Without Complexity', // TODO: Figure out a dynamic place for the app title
+      ...(referer ? { 'HTTP-Referer': referer } : {}),
+      ...(title ? { 'X-Title': title } : {}),
     },
     body: JSON.stringify(request),
   })


### PR DESCRIPTION
## Summary
- make AI request helper headers configurable via `referer` and `title`
- expose `AI_REFERER` and `AI_TITLE` environment variables

## Testing
- `pnpm test:unit` *(fails: ConnectTimeoutError)*