### PR TITLE
feat: build out gpt.do sdk

### DIFF
--- a/sdks/gpt.do/package.json
+++ b/sdks/gpt.do/package.json
@@ -41,7 +41,7 @@
   "scripts": {
     "build": "tsc",
     "build:packages": "tsc",
-    "test": "echo \"No tests\" && exit 0"
+    "test": "vitest run"
   },
   "dependencies": {
     "apis.do": "workspace:*"

--- a/sdks/gpt.do/src/__tests__/unit.test.ts
+++ b/sdks/gpt.do/src/__tests__/unit.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { generateText } from '../index'
+import CLI from '../cli'
+
+const mockFetch = vi.fn()
+global.fetch = mockFetch as unknown as typeof fetch
+
+describe('gpt.do SDK', () => {
+  beforeEach(() => {
+    vi.resetAllMocks()
+
+    const mockResponse = {
+      choices: [{ message: { content: 'Hello World' } }],
+      usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+    }
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockResponse),
+    } as Response)
+  })
+
+  it('generateText should call the API and return text', async () => {
+    const result = await generateText('Hello')
+
+    expect(result.text).toBe('Hello World')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+    expect(mockFetch.mock.calls[0][0]).toContain('/llm/chat/completions')
+  })
+
+  it('CLI.generate should proxy to generateText', async () => {
+    const cli = new CLI({ apiKey: 'test' })
+    const res = await cli.generate('Hi')
+
+    expect(res.text).toBe('Hello World')
+    expect(mockFetch).toHaveBeenCalledTimes(1)
+  })
+})
+

--- a/sdks/gpt.do/src/cli.ts
+++ b/sdks/gpt.do/src/cli.ts
@@ -1,0 +1,18 @@
+import { CLI as ApisCLI } from 'apis.do/src/cli'
+import { generateText, GPTOptions, GPTResponse } from './index'
+
+export class CLI extends ApisCLI {
+  /**
+   * Generate text using the GPT API
+   */
+  async generate(prompt: string, options: GPTOptions = {}): Promise<GPTResponse> {
+    const apiKey =
+      options.apiKey ||
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (this as any).api?.headers?.Authorization?.replace('Bearer ', '')
+
+    return generateText(prompt, { ...options, apiKey })
+  }
+}
+
+export default CLI

--- a/sdks/gpt.do/src/index.ts
+++ b/sdks/gpt.do/src/index.ts
@@ -3,11 +3,29 @@
  * A simplified interface for GPT models with enhanced capabilities
  */
 
+import { API } from 'apis.do'
+
 export interface GPTOptions {
+  /**
+   * Model identifier to use for generation
+   */
   model?: string
+  /**
+   * Temperature to use for generation
+   */
   temperature?: number
+  /**
+   * Maximum number of tokens to return
+   */
   maxTokens?: number
+  /**
+   * Optional API key to use instead of the default
+   */
   apiKey?: string
+  /**
+   * Base URL for the API (defaults to https://apis.do)
+   */
+  baseUrl?: string
 }
 
 export interface GPTResponse {
@@ -26,13 +44,23 @@ export interface GPTResponse {
  * @returns Generated text response
  */
 export async function generateText(prompt: string, options: GPTOptions = {}): Promise<GPTResponse> {
+  const api = new API({ apiKey: options.apiKey, baseUrl: options.baseUrl })
+
+  const body: Record<string, any> = {
+    model: options.model || 'gpt-3.5-turbo',
+    messages: [{ role: 'user', content: prompt }],
+    stream: false,
+  }
+
+  if (options.temperature !== undefined) body.temperature = options.temperature
+  if (options.maxTokens !== undefined) body.max_tokens = options.maxTokens
+
+  const result = await api.post<any>('/llm/chat/completions', body)
+  const text = result?.choices?.[0]?.message?.content || ''
+
   return {
-    text: `Response to: ${prompt}`,
-    usage: {
-      promptTokens: prompt.length,
-      completionTokens: 0,
-      totalTokens: prompt.length,
-    },
+    text,
+    usage: result.usage,
   }
 }
 

--- a/sdks/gpt.do/vitest.config.ts
+++ b/sdks/gpt.do/vitest.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from 'vitest/config'
+import { resolve } from 'path'
+
+export default defineConfig({
+  test: {
+    include: ['**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    environment: 'node',
+  },
+  resolve: {
+    alias: {
+      '@payload-config': resolve(__dirname, '../../payload.config.ts'),
+      '@': resolve(__dirname, '../..'),
+      '@/lib': resolve(__dirname, '../../lib'),
+      '@/.velite': resolve(__dirname, '../../.velite'),
+      '@/app': resolve(__dirname, '../../app'),
+      '@/collections': resolve(__dirname, '../../collections'),
+      '@/tasks': resolve(__dirname, '../../tasks'),
+      '@/scripts': resolve(__dirname, '../../scripts'),
+    },
+  },
+})
+


### PR DESCRIPTION
## Summary
- update gpt.do to depend on `apis.do`
- implement API calls in `src/index.ts`
- add CLI class extending `apis.do` commands
- add unit tests and vitest config

## Testing
- `pnpm --filter ./sdks/gpt.do test` *(fails: Connect Timeout Error)*